### PR TITLE
Updated Renovate configuration to ignore ember-exam

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   "ignoreDeps": [
     "ember-drag-drop",
     "normalize.css",
-    "validator"
+    "validator",
+    "ember-exam"
   ],
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },


### PR DESCRIPTION
no issue
- latest `ember-exam` is not compatible with latest stable `ember-mocha` release
- see https://github.com/ember-cli/ember-exam/issues/238