### PR TITLE
Added guard against undefined member name

### DIFF
--- a/app/components/gh-member-avatar.js
+++ b/app/components/gh-member-avatar.js
@@ -32,7 +32,7 @@ export default Component.extend({
     initials: computed('member.name', function () {
         let name = this.member.name;
         if (name) {
-            let names = this.member.name.split(' ');
+            let names = name.split(' ');
             let intials = [names[0][0], names[names.length - 1][0]];
             return intials.join('').toUpperCase();
         }


### PR DESCRIPTION
no-issue

This is causing issues since we removed the name property from member
objects. This change stops admin crashing out, but a more correct
handling of the missing name property should happen at a later point.