### PR TITLE
Added Connect with Stripe button for testmode

### DIFF
--- a/app/components/gh-members-lab-setting.hbs
+++ b/app/components/gh-members-lab-setting.hbs
@@ -66,7 +66,8 @@
             <div class="flex flex-column flex-row-l items-start justify-between mb4 mt6">
                 <div class="w-100 w-50-l">
                     <div class="mb4">
-                        <a href="{{this.stripeConnectAuthUrl}}" class="stripe-connect" target="_blank"><span>Connect with Stripe</span></a>
+                        <a href="{{this.liveStripeConnectAuthUrl}}" class="stripe-connect" target="_blank"><span>Connect with Stripe</span></a>
+                        <a href="{{this.testStripeConnectAuthUrl}}" class="stripe-connect" target="_blank"><span>Connect with Stripe (testmode)</span></a>
                     </div>
                     <div class="nudge-top--3">
                         <label class="fw6 f8 mt4">Stripe Connect authentication token</label>

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -215,7 +215,11 @@ export default Component.extend({
         }
     }).drop(),
 
-    get stripeConnectAuthUrl() {
-        return this.ghostPaths.url.api('members/stripe_connect');
+    get liveStripeConnectAuthUrl() {
+        return this.ghostPaths.url.api('members/stripe_connect') + '?mode=live';
+    },
+
+    get testStripeConnectAuthUrl() {
+        return this.ghostPaths.url.api('members/stripe_connect') + '?mode=test';
     }
 });


### PR DESCRIPTION
no-issue

This PR replaces the stripeConnectAuthUrl with a live and test one,
which can be used to connect either a live or a test account.

