### PR TITLE
Allow YAML file for redirects.

### DIFF
--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -49,8 +49,8 @@ export default Controller.extend({
     uploadButtonText: 'Import',
 
     importMimeType: null,
-    jsonExtension: null,
-    jsonMimeType: null,
+    redirectsFileExtensions: null,
+    redirectsFileMimeTypes: null,
     yamlExtension: null,
     yamlMimeType: null,
 
@@ -59,8 +59,9 @@ export default Controller.extend({
     init() {
         this._super(...arguments);
         this.importMimeType = IMPORT_MIME_TYPES;
-        this.jsonExtension = JSON_EXTENSION;
-        this.jsonMimeType = JSON_MIME_TYPE;
+        this.redirectsFileExtensions = [...JSON_EXTENSION, ...YAML_EXTENSION];
+        // .yaml is added below for file dialogs to show .yaml by default.
+        this.redirectsFileMimeTypes = [...JSON_MIME_TYPE, ...YAML_MIME_TYPE, '.yaml'];
         this.yamlExtension = YAML_EXTENSION;
         this.yamlMimeType = YAML_MIME_TYPE;
         // (macOS) Safari only allows files with the `yml` extension to be selected with the specified MIME types

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -84,8 +84,8 @@
             <div class="gh-expandable">
                 <div class="gh-expandable-block">
                     <GhUploader
-                        @extensions={{this.jsonExtension}}
-                        @uploadUrl="/redirects/json/"
+                        @extensions={{this.redirectsFileExtensions}}
+                        @uploadUrl="/redirects/upload/"
                         @paramName="redirects"
                         @onUploadSuccess={{perform this.redirectUploadResult true}}
                         @onUploadFailure={{perform this.redirectUploadResult false}}
@@ -112,11 +112,11 @@
                                         {{else if this.redirectFailure}}
                                             {{svg-jar "retry"}} Upload Failed
                                         {{else}}
-                                            Upload redirects JSON
+                                            Upload redirects YAML/JSON
                                         {{/if}}
                                     </span>
                                 </button>
-                                <div><a href="#" {{action "downloadFile" "redirects/json"}} data-test-link="download-redirects">Download current redirects</a></div>
+                                <div><a href="#" {{action "downloadFile" "redirects/download"}} data-test-link="download-redirects">Download current redirects</a></div>
                             {{/if}}
 
                             {{#each uploader.errors as |error|}}
@@ -124,7 +124,7 @@
                             {{/each}}
 
                             <div style="display:none">
-                                <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.jsonMimeType}} data-test-file-input="redirects" />
+                                <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.redirectsFileMimeTypes}} data-test-file-input="redirects" />
                             </div>
                         </div>
                     </div>

--- a/tests/acceptance/settings/labs-test.js
+++ b/tests/acceptance/settings/labs-test.js
@@ -82,7 +82,7 @@ describe('Acceptance: Settings - Labs', function () {
             await visit('/settings/labs');
 
             // successful upload
-            this.server.post('/redirects/json/', {}, 200);
+            this.server.post('/redirects/upload/', {}, 200);
 
             await fileUpload(
                 '[data-test-file-input="redirects"] input',
@@ -123,7 +123,7 @@ describe('Acceptance: Settings - Labs', function () {
             ).to.have.string('Upload redirects');
 
             // failed upload
-            this.server.post('/redirects/json/', {
+            this.server.post('/redirects/upload/', {
                 errors: [{
                     type: 'BadRequestError',
                     message: 'Test failure message'
@@ -175,7 +175,7 @@ describe('Acceptance: Settings - Labs', function () {
             ).to.have.string('Upload redirects');
 
             // successful upload clears error
-            this.server.post('/redirects/json/', {}, 200);
+            this.server.post('/redirects/upload/', {}, 200);
             await fileUpload(
                 '[data-test-file-input="redirects"] input',
                 ['test'],
@@ -188,7 +188,7 @@ describe('Acceptance: Settings - Labs', function () {
             await click('[data-test-link="download-redirects"]');
 
             let iframe = document.querySelector('#iframeDownload');
-            expect(iframe.getAttribute('src')).to.have.string('/redirects/json/');
+            expect(iframe.getAttribute('src')).to.have.string('/redirects/download/');
         });
 
         it('can upload/download routes.yaml', async function () {


### PR DESCRIPTION
ref TryGhost/Ghost#11085
ref TryGhost/Ghost#12187

This PR allows users to upload yaml format redirects files to the server.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
