### PR TITLE
Dispatch event to root only if the key combo is registered as shortcut

### DIFF
--- a/app/components/gh-token-input.js
+++ b/app/components/gh-token-input.js
@@ -1,6 +1,7 @@
 /* global key */
 import Component from '@glimmer/component';
 import Ember from 'ember';
+import shortcuts from '../utils/shortcuts';
 import {A, isArray} from '@ember/array';
 import {action, get} from '@ember/object';
 import {
@@ -91,11 +92,14 @@ export default class GhTokenInput extends Component {
         // ember-power-select stops propagation of events when ctrl/CMD or meta key is down.
         // So, we're dispatching KeyboardEvent directly to the root of ghost app.
         if (event.ctrlKey || event.metaKey) {
-            const copy = new KeyboardEvent(event.type, event);
-            document.getElementsByClassName('gh-app')[0].dispatchEvent(copy);
-            event.preventDefault(); // don't show the save dialog.
+            // Only dispatch KeyboardEvent to the root when it's a registered shortcut.
+            if (shortcuts.includes(event)) {
+                const copy = new KeyboardEvent(event.type, event);
+                document.getElementsByClassName('gh-app')[0].dispatchEvent(copy);
+                event.preventDefault(); // don't show the save dialog.
 
-            return false;
+                return false;
+            }
         }
 
         // fallback to default

--- a/app/mixins/shortcuts.js
+++ b/app/mixins/shortcuts.js
@@ -3,6 +3,8 @@ import Mixin from '@ember/object/mixin';
 import {run} from '@ember/runloop';
 import {typeOf} from '@ember/utils';
 
+import shortcutsCache from '../utils/shortcuts';
+
 // Configure KeyMaster to respond to all shortcuts,
 // even inside of
 // input, textarea, and select.
@@ -58,6 +60,8 @@ export default Mixin.create({
                 action = action.action;
             }
 
+            shortcutsCache.register(shortcut);
+
             key(shortcut, scope, (event) => {
                 // stop things like ctrl+s from actually opening a save dialog
                 event.preventDefault();
@@ -73,6 +77,7 @@ export default Mixin.create({
 
         Object.keys(shortcuts).forEach((shortcut) => {
             let scope = shortcuts[shortcut].scope || 'default';
+            shortcutsCache.unregister(shortcut);
             key.unbind(shortcut, scope);
         });
     },

--- a/app/utils/shortcuts.js
+++ b/app/utils/shortcuts.js
@@ -1,0 +1,41 @@
+const cache = {};
+
+export function includes(event) {
+    const keys = [];
+    let ctrlPressed = false;
+
+    if (event.ctrlKey) {
+        keys.push('ctrl');
+        ctrlPressed = true;
+    }
+
+    if (event.shiftKey) {
+        keys.push('shift');
+    }
+
+    if (event.altKey) {
+        keys.push('alt');
+    }
+
+    keys.push(event.key);
+
+    const exists = cache[keys.join('+')];
+
+    if (!exists && ctrlPressed) { // Test things like cmd+s
+        return cache[keys.join('+').replace('ctrl', 'cmd')];
+    }
+
+    return exists;
+}
+
+export function register(shortcut) {
+    cache[shortcut.toLowerCase()] = true;
+}
+
+export function unregister(shortcut) {
+    delete cache[shortcut];
+}
+
+export function getAll() {
+    return Object.assign({}, cache);
+}


### PR DESCRIPTION
Closes TryGhost/Ghost#12294.

Cache registered shortcuts and check KeyboardEvent before dispatching event to the root.

Fixed the bug introduced with TryGhost/Ghost-Admin#1707.

I wish there were a way to test ctrl+v event. But unfortunately, native events are not executed by triggering event in the acceptance tests.

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
