### PR TITLE
Close impersonate modal when navigating away from members page

### DIFF
--- a/app/controllers/member.js
+++ b/app/controllers/member.js
@@ -65,6 +65,11 @@ export default class MemberController extends Controller {
     }
 
     @action
+    closeImpersonateMemberModal() {
+        this.showImpersonateMemberModal = false;
+    }
+
+    @action
     save() {
         return this.saveTask.perform();
     }

--- a/app/routes/member.js
+++ b/app/routes/member.js
@@ -13,6 +13,7 @@ export default class MembersRoute extends AuthenticatedRoute {
         super.init(...arguments);
         this.router.on('routeWillChange', (transition) => {
             this.showUnsavedChangesModal(transition);
+            this.closeImpersonateModal(transition);
         });
     }
 
@@ -70,6 +71,16 @@ export default class MembersRoute extends AuthenticatedRoute {
                 controller.toggleUnsavedChangesModal(transition);
                 return;
             }
+        }
+    }
+
+    closeImpersonateModal(transition) {
+        // If user navigates away with forward or back button, ensure returning to page 
+        // hides modal
+        if (transition.from && transition.from.name === this.routeName && transition.targetName) {
+            let {controller} = this;
+
+            controller.closeImpersonateMemberModal(transition);
         }
     }
 }


### PR DESCRIPTION
refs/closes [Ghost/#12214](https://github.com/TryGhost/Ghost/issues/12214)
Previously, when navigating back from the members page with the
impersonate modal open, opening a new member showed the impersonate modal.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
