### PR TITLE
Allow non-FQDNs in webhook URLs

### DIFF
--- a/app/validators/webhook.js
+++ b/app/validators/webhook.js
@@ -28,7 +28,7 @@ export default BaseValidator.create({
     targetUrl(model) {
         if (isBlank(model.targetUrl)) {
             model.errors.add('targetUrl', 'Please enter a target URL');
-        } else if (!validator.isURL(model.targetUrl || '', {require_protocol: false})) {
+        } else if (!validator.isURL(model.targetUrl || '', {require_protocol: false, require_tld: false})) {
             model.errors.add('targetUrl', 'Please enter a valid URL');
         } else if (!validator.isLength(model.targetUrl, 0, 2000)) {
             model.errors.add('targetUrl', 'Target URL is too long, max 2000 chars');


### PR DESCRIPTION
no issue

I need this change in order to comfortably use webhooks in my Docker environment.
My plan was to have my ghost container along with a custom webhook receiver application in the same network.
This way, automatic DNS discovery would be enabled and I could just use the name of my service as a webhook endpoint.
However, docker doesn't allow dots in service names, so the DNS entry for my receiver is always a single level domain.
The fix for this is simple: Just disable the check for a top-level domain in the webhook validator.
That happens here: https://github.com/validatorjs/validator.js/blob/master/src/lib/isFQDN.js#L24
I don't see any issues that could arise from disabling this check.