### PR TITLE
Show embedded items in correct size.

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-card-embed.js
+++ b/lib/koenig-editor/addon/components/koenig-card-embed.js
@@ -312,8 +312,16 @@ export default Component.extend({
         // get ratio from nested iframe if present (eg, Vimeo)
         let firstElement = iframe.contentDocument.body.firstChild;
         if (firstElement.tagName === 'IFRAME') {
-            let width = parseInt(firstElement.getAttribute('width'));
-            let height = parseInt(firstElement.getAttribute('height'));
+            let width = firstElement.getAttribute('width');
+            let height = firstElement.getAttribute('height');
+
+            if (width === '100%') {
+                iframe.style.height = `${height}px`;
+                return;
+            }
+
+            width = parseInt(width);
+            height = parseInt(height);
             if (width && height) {
                 let ratio = width / height;
                 let newHeight = iframe.offsetWidth / ratio;


### PR DESCRIPTION
ref TryGhost/Ghost#12018

Removing maxWidth:1280 option sets the width attribute of iframe to 100% and parseInt parses it to 100(px). It creates abnormal height in embedded items in the koenig editor. So, this commit makes the editor to handle the value(100%) correctly.

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
