### PR TITLE
Stop enter propagation in Portal modal window.

### DIFF
--- a/app/components/modal-portal-settings.hbs
+++ b/app/components/modal-portal-settings.hbs
@@ -114,6 +114,7 @@
                                             @placeholder="abcdef"
                                             @autocorrect="off"
                                             @maxlength="6"
+                                            @keyDown={{action "accentColorKeydown"}}
                                             @focus-out={{action "validateAccentColor"}}
                                             @value={{accentColor}}
                                             data-test-input="accentColor"
@@ -244,6 +245,7 @@
                                     @value={{readonly this.settings.portalButtonSignupText}}
                                     @type="text"
                                     @input={{action "setSignupButtonText"}}
+                                    @stopEnterKeyDownPropagation={{true}}
                                 />
                             </div>
                         </GhFormGroup>

--- a/app/components/modal-portal-settings.js
+++ b/app/components/modal-portal-settings.js
@@ -202,6 +202,13 @@ export default ModalComponent.extend({
             }
         },
 
+        accentColorKeydown(event) {
+            if (event.keyCode === 13) { // Enter
+                this.send('validateAccentColor');
+                event.stopPropagation();
+            }
+        },
+
         updateAccentColor(color) {
             this._validateAccentColor(color);
         },


### PR DESCRIPTION
closes TryGhost/Ghost#12252

There were 2 accidental closes: accent color and signup text. 
And we're changing the value of accent color when pressing enter.

The tests should be added with TryGhost/Ghost#12254. 

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
