### PR TITLE
Updated usage of subscriptions data for members

### DIFF
--- a/app/components/gh-member-settings-form.js
+++ b/app/components/gh-member-settings-form.js
@@ -20,7 +20,7 @@ export default Component.extend({
     // Allowed actions
     setProperty: () => {},
 
-    hasMultipleSubscriptions: gt('member.stripe', 1),
+    hasMultipleSubscriptions: gt('member.subscriptions', 1),
 
     canShowStripeInfo: computed('member.isNew', 'membersUtils.isStripeEnabled', function () {
         let stripeEnabled = this.membersUtils.isStripeEnabled;
@@ -32,8 +32,8 @@ export default Component.extend({
         }
     }),
 
-    subscriptions: computed('member.stripe', function () {
-        let subscriptions = this.member.get('stripe');
+    subscriptions: computed('member.subscriptions', function () {
+        let subscriptions = this.member.get('subscriptions');
         if (subscriptions && subscriptions.length > 0) {
             return subscriptions.map((subscription) => {
                 const statusLabel = subscription.status ? subscription.status.replace('_', ' ') : '';

--- a/app/models/member.js
+++ b/app/models/member.js
@@ -10,7 +10,7 @@ export default Model.extend(ValidationEngine, {
     email: attr('string'),
     note: attr('string'),
     createdAtUTC: attr('moment-utc'),
-    stripe: attr('member-subscription'),
+    subscriptions: attr('member-subscription'),
     subscribed: attr('boolean', {defaultValue: true}),
     comped: attr('boolean', {defaultValue: false}),
     geolocation: attr('json-string'),

--- a/app/transforms/member-subscription.js
+++ b/app/transforms/member-subscription.js
@@ -6,7 +6,7 @@ export default Transform.extend({
     deserialize(serialized) {
         let subscriptions, subscriptionArray;
 
-        subscriptionArray = serialized.subscriptions || [];
+        subscriptionArray = serialized || [];
 
         subscriptions = subscriptionArray.map(itemDetails => MemberSubscription.create(itemDetails));
 
@@ -24,8 +24,6 @@ export default Transform.extend({
             subscriptionArray = [];
         }
 
-        return {
-            subscriptions: subscriptionArray
-        };
+        return subscriptionArray;
     }
 });


### PR DESCRIPTION
no issue

- The subscriptions data on member - `stripe.subscriptions` - is flattened to top level `subscriptions` with a new provider value to check for subscription provider
- Updates model to use the new data structure
- Updates serializer to handle new data structure