### PR TITLE
Updated paid member filters to handle comped status

### DIFF
--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -218,7 +218,7 @@ export default Component.extend({
     }),
 
     countPaidMembersTask: task(function* () {
-        const result = yield this.store.query('member', {filter: 'subscribed:true+status:paid', limit: 1, page: 1});
+        const result = yield this.store.query('member', {filter: 'subscribed:true+status:-free', limit: 1, page: 1});
         const paidMemberCount = result.meta.pagination.total;
         const freeMemberCount = this.memberCount - paidMemberCount;
         this.set('paidMemberCount', paidMemberCount);

--- a/app/components/modal-confirm-email-send.js
+++ b/app/components/modal-confirm-email-send.js
@@ -22,7 +22,7 @@ export default ModalComponent.extend({
     }),
 
     countPaidMembersTask: task(function* () {
-        const result = yield this.store.query('member', {filter: 'subscribed:true+status:paid', limit: 1, page: 1});
+        const result = yield this.store.query('member', {filter: 'subscribed:true+status:-free', limit: 1, page: 1});
         this.set('paidMemberCount', result.meta.pagination.total);
         const freeMemberCount = this.model.memberCount - result.meta.pagination.total;
         this.set('freeMemberCount', freeMemberCount);

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -165,7 +165,7 @@ export default class MembersController extends Controller {
         let filters = [];
         if (this.paidParam !== null) {
             if (this.paidParam === 'true') {
-                filters.push('status:paid');
+                filters.push('status:-free');
             } else {
                 filters.push('status:free');
             }
@@ -292,7 +292,7 @@ export default class MembersController extends Controller {
             }
             if (paidParam !== null) {
                 if (paidParam === 'true') {
-                    filters.push('status:paid');
+                    filters.push('status:-free');
                 } else {
                     filters.push('status:free');
                 }
@@ -329,7 +329,7 @@ export default class MembersController extends Controller {
         }
         if (paidParam !== null) {
             if (paidParam === 'true') {
-                filters.push('status:paid');
+                filters.push('status:-free');
             } else {
                 filters.push('status:free');
             }


### PR DESCRIPTION
no-issue

As members can now have a status of 'comped' as well as 'free'/'paid',
we need to update queries to the API to function as they were before.