### PR TITLE
Made PSM social subviews wider

### DIFF
--- a/app/components/gh-post-settings-menu.hbs
+++ b/app/components/gh-post-settings-menu.hbs
@@ -1,4 +1,4 @@
-<div class="settings-menu-container">
+<div class="settings-menu-container {{if this.wideSubview "settings-menu-container--wide"}}">
     <div id="entry-controls">
         <div class="{{if this.isViewingSubview 'settings-menu-pane-out-left' 'settings-menu-pane-in'}} settings-menu settings-menu-pane">
             <div class="settings-menu-header">
@@ -108,21 +108,21 @@
                 {{/unless}}
 
                 <ul class="nav-list nav-list-block">
-                    <li class="nav-list-item" {{action "showSubview" "meta-data"}} data-test-button="meta-data">
+                    <li class="nav-list-item" {{action "showSubview" "meta-data" "wide"}} data-test-button="meta-data">
                         <button type="button">
                             <b>Meta data</b>
                             <span>Extra content for search engines</span>
                         </button>
                         {{svg-jar "arrow-right"}}
                     </li>
-                    <li class="nav-list-item" {{action "showSubview" "twitter-data"}} data-test-button="twitter-data">
+                    <li class="nav-list-item" {{action "showSubview" "twitter-data" "wide"}} data-test-button="twitter-data">
                         <button type="button">
                             <b>Twitter card</b>
                             <span>Customise structured data for Twitter</span>
                         </button>
                         {{svg-jar "arrow-right"}}
                     </li>
-                    <li class="nav-list-item" {{action "showSubview" "facebook-data"}} data-test-button="facebook-data">
+                    <li class="nav-list-item" {{action "showSubview" "facebook-data" "wide"}} data-test-button="facebook-data">
                         <button type="button">
                             <b>Facebook card</b>
                             <span>Customise Open Graph data</span>

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -129,10 +129,11 @@ export default Component.extend(SettingsMenuMixin, {
     },
 
     actions: {
-        showSubview(subview) {
+        showSubview(subview, wide = false) {
             this._super(...arguments);
 
             this.set('subview', subview);
+            this.set('wideSubview', wide);
 
             // Chrome appears to have an animation bug that cancels the slide
             // transition unless there's a delay between the animation starting
@@ -146,6 +147,7 @@ export default Component.extend(SettingsMenuMixin, {
             this._super(...arguments);
 
             this.set('subview', null);
+            this.set('wideSubview', false);
             this.showThrobbers.perform();
         },
 

--- a/app/styles/components/settings-menu.css
+++ b/app/styles/components/settings-menu.css
@@ -20,6 +20,10 @@
     box-shadow: none;
 }
 
+.settings-menu-container--wide {
+    width: 500px;
+}
+
 .settings-menu-expanded .settings-menu-container {
     transform: translate3d(0, 0px, 0px);
     box-shadow:
@@ -291,7 +295,7 @@
 /* Background
 /* ---------------------------------------------------------- */
 @keyframes coverFadeIn {
-    0% { 
+    0% {
         opacity: 0;
     }
     100% {


### PR DESCRIPTION
no issue

- adds an extra class to the PSM container to increase it's width when viewing a wide subview
- made meta and social subviews "wide" to create space for the more realistic previews that are used in the preview modal