### PR TITLE
Ensured redirect for /billing route when not signed in

### DIFF
--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -3,12 +3,21 @@ import {inject as service} from '@ember/service';
 
 export default Route.extend({
     billing: service(),
+    session: service(),
 
     queryParams: {
         action: {refreshModel: true}
     },
 
     beforeModel(transition) {
+        this._super(...arguments);
+
+        // Ensure that we redirect to signin if billing route is
+        // requested without a valid session
+        if (!this.get('session.isAuthenticated')) {
+            return this.transitionTo('signin');
+        }
+
         this.billing.set('previousTransition', transition);
     },
 


### PR DESCRIPTION
no issue

Fixes a bug where the billing iframe would show a blank page when called directly and user is not logged in. This commit ensures to that we have a valid authenticated session and redirects to the signin page if not.