### PR TITLE
Billing iframe 3x

### DIFF
--- a/app/components/gh-billing-modal.hbs
+++ b/app/components/gh-billing-modal.hbs
@@ -1,10 +1,5 @@
 <div class="{{this.visibilityClass}}">
     <div class="gh-billing-container">
-        <div class="gh-billing-close">
-            <button class="close" href title="Close" {{on "click" (action "closeModal")}}>
-                {{svg-jar "close"}}
-            </button>
-        </div>
 
         <GhBillingIframe></GhBillingIframe>
     </div>

--- a/app/components/gh-billing-modal.js
+++ b/app/components/gh-billing-modal.js
@@ -21,12 +21,6 @@ export default Component.extend({
         this._removeShortcuts();
     },
 
-    actions: {
-        closeModal() {
-            this.billing.closeBillingWindow();
-        }
-    },
-
     _setupShortcuts() {
         run(function () {
             document.activeElement.blur();
@@ -38,16 +32,11 @@ export default Component.extend({
             this.send('confirm');
         });
 
-        key('escape', 'modal', () => {
-            this.send('closeModal');
-        });
-
         key.setScope('modal');
     },
 
     _removeShortcuts() {
         key.unbind('enter', 'modal');
-        key.unbind('escape', 'modal');
         key.setScope(this._previousKeymasterScope);
     }
 });

--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -40,7 +40,7 @@ export default AuthenticatedRoute.extend({
                         ? transition.intent.url
                         : '');
 
-                if (destinationUrl.includes('/billing')) {
+                if (destinationUrl?.includes('/billing')) {
                     isBillingTransition = true;
                 }
             }

--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject as service} from '@ember/service';
 
-export default Route.extend({
+export default AuthenticatedRoute.extend({
     billing: service(),
     ui: service(),
 

--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -10,6 +10,7 @@ export default AuthenticatedRoute.extend({
     },
 
     beforeModel(transition) {
+        this._super(...arguments);
         this.billing.set('previousTransition', transition);
     },
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -21,6 +21,10 @@
 
         <main class="gh-main {{this.ui.mainClass}}" role="main">
             {{outlet}}
+
+            {{#if this.showBilling}}
+                <GhBillingModal />
+            {{/if}}
         </main>
 
         <GhNotifications />
@@ -40,9 +44,6 @@
         />
     {{/if}}
 
-    {{#if this.showBilling}}
-        <GhBillingModal />
-    {{/if}}
 </GhApp>
 
 <EmberLoadRemover />


### PR DESCRIPTION
refs https://github.com/TryGhost/Admin/pull/1838
refs https://github.com/TryGhost/Admin/pull/1859

Same changes needed to be done for 3.x

The billing iFrame needs to be rendered within the main content area rather than as fullscreen.
This needs most probably more tidying up, but is working for now without breaking the functionality.

Fixes a bug where the billing iframe would show a blank page when called directly and user is not logged in. This commit ensures to that we have a valid authenticated session and redirects to the signin page if not.