### PR TITLE
Fixed selected currency in payment settings

### DIFF
--- a/app/components/gh-members-payments-setting.js
+++ b/app/components/gh-members-payments-setting.js
@@ -41,7 +41,7 @@ export default Component.extend({
     portalSettingsBorderColor: reads('settings.accentColor'),
 
     selectedCurrency: computed('stripePlans.monthly.currency', function () {
-        return this.get('currencies').findBy('value', this.get('stripePlans.monthly.currency'));
+        return this.get('currencies').findBy('value', this.get('stripePlans.monthly.currency')) || this.get('topCurrencies').findBy('value', this.get('stripePlans.monthly.currency'));
     }),
 
     blogDomain: computed('config.blogDomain', function () {


### PR DESCRIPTION
no refs

For selected currency, we were only checking in the secondary currency list which does not include the top currencies like USD, so if the current selected currency is one of the top currencies, the `selectedCurrency` returned a value of `undefined`. The fix updates selected currency computation to check both top and other currencies
