### PR TITLE
🐛 Fixed MRR start date value in chart

### DIFF
--- a/app/services/members-stats.js
+++ b/app/services/members-stats.js
@@ -87,7 +87,13 @@ export default class MembersStatsService extends Service {
 
         let endDate = moment().add(1, 'hour');
         const output = {};
-        let lastVal = 0;
+
+        const firstDateInRangeIndex = data.findIndex((val) => {
+            return moment(val.date).isAfter(currentRangeDate);
+        });
+        const initialDateInRangeVal = firstDateInRangeIndex > 0 ? data[firstDateInRangeIndex - 1] : null;
+        let lastVal = initialDateInRangeVal ? initialDateInRangeVal.value : 0;
+
         while (currentRangeDate.isBefore(endDate)) {
             let dateStr = currentRangeDate.format('YYYY-MM-DD');
             const dataOnDate = data.find(d => d.date === dateStr);

--- a/tests/unit/services/member-stats-test.js
+++ b/tests/unit/services/member-stats-test.js
@@ -1,0 +1,35 @@
+import moment from 'moment';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Service: membersStats', function () {
+    setupTest();
+
+    let memberStatsService;
+
+    beforeEach(function () {
+        memberStatsService = this.owner.lookup('service:membersStats');
+    });
+
+    it('fills correct date and value for mrr data', function () {
+        const data = [
+            {
+                date: moment().subtract(31, 'days').format('YYYY-MM-DD'),
+                value: 14459
+            },
+            {
+                date: moment().subtract(10, 'days').format('YYYY-MM-DD'),
+                value: 98176
+            }
+        ];
+        const output = memberStatsService.fillDates(data);
+        const values = Object.values(output);
+        const keys = Object.keys(output);
+
+        expect(values[0]).to.equal(14459);
+        expect(keys[0]).to.equal(moment().subtract(30, 'days').format('YYYY-MM-DD'));
+        expect(keys[keys.length - 1]).to.equal(moment().format('YYYY-MM-DD'));
+        expect(values[values.length - 1]).to.equal(98176);
+    });
+});


### PR DESCRIPTION
no refs

MRR start date value for charts was being calculated with start value as 0, assuming we have the data for first date in our range to use as start value. Since the events data returned only has data on dates where any MRR event happened, in case the first date in our range didn't have any. data we started from 0 instead of value on previous date. This fix

- adds calculation to pick the start value for chart based on value on last date in our range(30 days)
- adds unit tests for stats
