### PR TITLE
Fixed billing/update links showing for admins

### DIFF
--- a/app/components/gh-nav-menu/main.hbs
+++ b/app/components/gh-nav-menu/main.hbs
@@ -88,7 +88,7 @@
             <li><LinkTo @route="staff" data-test-nav="staff">{{svg-jar "staff"}}Staff</LinkTo></li>
         </ul>
 
-        {{#if (gh-user-can-admin this.session.user)}}
+        {{#if this.session.user.isOwner}}
         <ul class="gh-nav-list">
             {{#if this.showBilling}}
                 <li class="relative">

--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -3,6 +3,7 @@ import {inject as service} from '@ember/service';
 
 export default AuthenticatedRoute.extend({
     billing: service(),
+    session: service(),
 
     queryParams: {
         action: {refreshModel: true}
@@ -10,7 +11,14 @@ export default AuthenticatedRoute.extend({
 
     beforeModel(transition) {
         this._super(...arguments);
-        this.billing.set('previousTransition', transition);
+
+        return this.session.user.then((user) => {
+            if (!user.isOwner) {
+                return this.transitionTo('home');
+            }
+
+            this.billing.set('previousTransition', transition);
+        });
     },
 
     model(params) {


### PR DESCRIPTION
no issue

- only owners can generate tokens to identify as the publication so the billing app won't work for non-owners
