### PR TITLE
[3.x] Fixed broken billing and update links being shown to admins

### DIFF
--- a/app/components/gh-nav-menu.hbs
+++ b/app/components/gh-nav-menu.hbs
@@ -96,7 +96,7 @@
             </ul>
         {{/if}}
 
-        {{#if (and (gh-user-can-admin this.session.user) (or this.showBilling this.domainUrl))}}
+        {{#if (and this.session.user.isOwner (or this.showBilling this.domainUrl))}}
         <ul class="gh-nav-list gh-nav-settings">
             <li class="gh-nav-list-h">Ghost Pro</li>
             {{#if this.showBilling}}

--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -3,6 +3,7 @@ import {inject as service} from '@ember/service';
 
 export default AuthenticatedRoute.extend({
     billing: service(),
+    session: service(),
     ui: service(),
 
     queryParams: {
@@ -11,7 +12,14 @@ export default AuthenticatedRoute.extend({
 
     beforeModel(transition) {
         this._super(...arguments);
-        this.billing.set('previousTransition', transition);
+
+        return this.session.user.then((user) => {
+            if (!user.isOwner) {
+                return this.transitionTo('home');
+            }
+
+            this.billing.set('previousTransition', transition);
+        });
     },
 
     model(params) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,7 +2,7 @@
     <GhSkipLink @anchor=".gh-main">Skip to main content</GhSkipLink>
 
     {{#if this.session.isAuthenticated}}
-        {{#if (and (gh-user-can-admin this.session.user) this.updateUrl)}}
+        {{#if (and this.session.user.isOwner this.updateUrl)}}
             <aside class="gh-update-banner">
                 <div class="gh-alert-content">
                     A new major version of Ghost is available!


### PR DESCRIPTION
no issue

- only users with the Owner role can generate tokens used to identify a publication so the links wouldn't function for Administrators