### PR TITLE
🐛 Fixed deleting members to prompt cancellation

### DIFF
--- a/app/components/modal-delete-member.js
+++ b/app/components/modal-delete-member.js
@@ -18,7 +18,7 @@ export default ModalComponent.extend({
     cancelSubscriptions: reads('shouldCancelSubscriptions'),
 
     hasActiveStripeSubscriptions: computed('member', function () {
-        let subscriptions = this.member.get('stripe');
+        let subscriptions = this.member.get('subscriptions');
 
         if (!subscriptions || subscriptions.length === 0) {
             return false;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/546

Since https://github.com/TryGhost/Ghost/commit/26ee6483 and
https://github.com/TryGhost/Admin/commit/723269bc a members
subscriptions have not been on the `stripe` property.

This meant that all members were considered to not have subscriptions,
and so the modal would not display to option to cancel subscriptions.