### PR TITLE
Changed `/billing` route to `/pro`

### DIFF
--- a/app/components/gh-billing-update-button.js
+++ b/app/components/gh-billing-update-button.js
@@ -15,7 +15,7 @@ export default Component.extend({
 
     actions: {
         openBilling() {
-            this.billing.openBillingWindow(this.router.currentURL, '/billing/plans');
+            this.billing.openBillingWindow(this.router.currentURL, '/pro/billing/plans');
         }
     }
 });

--- a/app/router.js
+++ b/app/router.js
@@ -24,8 +24,8 @@ Router.map(function () {
     this.route('about');
     this.route('site');
 
-    this.route('billing', function () {
-        this.route('billing-sub', {path: '/*sub'});
+    this.route('pro', function () {
+        this.route('pro-sub', {path: '/*sub'});
     });
 
     this.route('posts');

--- a/app/routes/pro.js
+++ b/app/routes/pro.js
@@ -1,9 +1,9 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject as service} from '@ember/service';
 
+// TODO: rename billing route and service to /pro
 export default AuthenticatedRoute.extend({
     billing: service(),
-    session: service(),
     ui: service(),
 
     queryParams: {
@@ -12,14 +12,7 @@ export default AuthenticatedRoute.extend({
 
     beforeModel(transition) {
         this._super(...arguments);
-
-        return this.session.user.then((user) => {
-            if (!user.isOwner) {
-                return this.transitionTo('home');
-            }
-
-            this.billing.set('previousTransition', transition);
-        });
+        this.billing.set('previousTransition', transition);
     },
 
     model(params) {
@@ -49,7 +42,7 @@ export default AuthenticatedRoute.extend({
                         ? transition.intent.url
                         : '');
 
-                if (destinationUrl?.includes('/billing')) {
+                if (destinationUrl?.includes('/pro')) {
                     isBillingTransition = true;
                 }
             }
@@ -60,7 +53,7 @@ export default AuthenticatedRoute.extend({
 
     buildRouteInfoMetadata() {
         return {
-            titleToken: 'Billing'
+            titleToken: 'Ghost(Pro)'
         };
     }
 });

--- a/app/routes/pro.js
+++ b/app/routes/pro.js
@@ -12,7 +12,14 @@ export default AuthenticatedRoute.extend({
 
     beforeModel(transition) {
         this._super(...arguments);
-        this.billing.set('previousTransition', transition);
+
+        return this.session.user.then((user) => {
+            if (!user.isOwner) {
+                return this.transitionTo('home');
+            }
+
+            this.billing.set('previousTransition', transition);
+        });
     },
 
     model(params) {

--- a/app/services/billing.js
+++ b/app/services/billing.js
@@ -6,7 +6,7 @@ export default Service.extend({
     config: service(),
     ghostPaths: service(),
 
-    billingRouteRoot: '#/billing',
+    billingRouteRoot: '#/pro',
     billingWindowOpen: false,
     subscription: null,
     previousRoute: null,
@@ -53,7 +53,7 @@ export default Service.extend({
 
     // Controls billing window modal visibility and sync of the URL visible in browser
     // and the URL opened on the iframe. It is responsible to non user triggered iframe opening,
-    // for example: by entering "/billing" route in the URL or using history navigation (back and forward)
+    // for example: by entering "/pro" route in the URL or using history navigation (back and forward)
     setBillingWindowOpen(value) {
         let billingIframe = this.getBillingIframe();
 
@@ -73,9 +73,9 @@ export default Service.extend({
 
         // Ensures correct "getIframeURL" calculation when syncing iframe location
         // in setBillingWindowOpen
-        window.location.hash = childRoute || '/billing';
+        window.location.hash = childRoute || '/pro';
 
-        this.router.transitionTo(childRoute || '/billing');
+        this.router.transitionTo(childRoute || '/pro');
     },
 
     closeBillingWindow() {


### PR DESCRIPTION
no issue

The current `/billing` route needs to be renamed into `/pro`, so we can use sub-routes like `/pro/billing` and `/pro/domain` in the billing app.

Still left to do is to rename the billing service itself, but that can be done with another PR