### PR TITLE
Removed hardcoded accent color fallbacks

### DIFF
--- a/app/controllers/signin.js
+++ b/app/controllers/signin.js
@@ -36,7 +36,7 @@ export default Controller.extend(ValidationEngine, {
     signin: alias('model'),
 
     accentColor: computed('config.accent_color', function () {
-        let color = this.get('config.accent_color') || '#15171A';
+        let color = this.get('config.accent_color');
         return color;
     }),
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/536

From 4.0, we ensure and require that accent colour is always set. This change removes hardcoded accent color fallbacks to avoid confusion as well as cause accidental fallback that is undesired causing themes to look different
