### PR TITLE
Updated default MRR currency from settings

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -82,7 +82,7 @@ export default class DashboardController extends Controller {
             };
             if (currencyStats) {
                 const currencyStatsData = this.membersStats.fillDates(currencyStats.data) || {};
-                const dateValues = Object.values(currencyStatsData).map(val => val / 100);
+                const dateValues = Object.values(currencyStatsData).map(val => Math.round((val / 100)));
                 const currentMRR = dateValues.length ? dateValues[dateValues.length - 1] : 0;
                 const rangeStartMRR = dateValues.length ? dateValues[0] : 0;
                 const percentGrowth = rangeStartMRR !== 0 ? ((currentMRR - rangeStartMRR) / rangeStartMRR) * 100 : 0;

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -71,10 +71,14 @@ export default class DashboardController extends Controller {
         this.mrrStatsLoading = true;
         this.membersStats.fetchMRR().then((stats) => {
             this.mrrStatsLoading = false;
-            const statsData = stats.data;
-            let currencyStats = statsData[0] || {
+            const statsData = stats.data || [];
+            const defaultCurrency = this.getDefaultCurrency() || 'usd';
+            let currencyStats = statsData.find((stat) => {
+                return stat.currency === defaultCurrency;
+            });
+            currencyStats = currencyStats || {
                 data: [],
-                currency: 'usd'
+                currency: defaultCurrency
             };
             if (currencyStats) {
                 const currencyStatsData = this.membersStats.fillDates(currencyStats.data) || {};
@@ -238,6 +242,12 @@ export default class DashboardController extends Controller {
             this.whatsNewEntriesError = error;
             this.whatsNewEntriesLoading = false;
         });
+    }
+
+    getDefaultCurrency() {
+        const plans = this.settings.get('stripePlans') || [];
+        const monthly = plans.find(plan => plan.interval === 'month');
+        return monthly && monthly.currency;
     }
 
     @action

--- a/app/services/members-stats.js
+++ b/app/services/members-stats.js
@@ -112,7 +112,10 @@ export default class MembersStatsService extends Service {
         const firstDateInRangeIndex = data.findIndex((val) => {
             return moment(val.date).isAfter(currentRangeDate);
         });
-        const initialDateInRangeVal = firstDateInRangeIndex > 0 ? data[firstDateInRangeIndex - 1] : null;
+        let initialDateInRangeVal = firstDateInRangeIndex > 0 ? data[firstDateInRangeIndex - 1] : null;
+        if (data.length > 0 && !initialDateInRangeVal && firstDateInRangeIndex !== 0) {
+            initialDateInRangeVal = data[data.length - 1];
+        }
         let lastVal = {
             paid: initialDateInRangeVal ? initialDateInRangeVal.paid : 0,
             free: initialDateInRangeVal ? initialDateInRangeVal.free : 0,


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/550

The MRR chart relied on first currency from the list in case of data for multiple currencies, falling back to USD in case of no MRR data for the site. This can be misleading, specially when the active currency set in payment settings is different from one picked to show on MRR chart.

The change updates dashboard to always pick the currency from Payment settings as default for showing chart data.
