### PR TITLE
Removed www subdomain from default newsletter/support address

### DIFF
--- a/app/components/gh-members-email-setting.js
+++ b/app/components/gh-members-email-setting.js
@@ -59,7 +59,11 @@ export default Component.extend({
     blogDomain: computed('config.blogDomain', function () {
         let blogDomain = this.config.blogDomain || '';
         const domainExp = blogDomain.replace('https://', '').replace('http://', '').match(new RegExp('^([^/:?#]+)(?:[/:?#]|$)', 'i'));
-        return (domainExp && domainExp[1]) || '';
+        const domain = (domainExp && domainExp[1]) || '';
+        if (domain.startsWith('www.')) {
+            return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
+        }
+        return domain;
     }),
 
     mailgunRegion: computed('settings.mailgunBaseUrl', function () {

--- a/app/controllers/settings/members-email.js
+++ b/app/controllers/settings/members-email.js
@@ -45,7 +45,11 @@ export default Controller.extend({
     blogDomain: computed('config.blogDomain', function () {
         let blogDomain = this.config.blogDomain || '';
         const domainExp = blogDomain.replace('https://', '').replace('http://', '').match(new RegExp('^([^/:?#]+)(?:[/:?#]|$)', 'i'));
-        return (domainExp && domainExp[1]) || '';
+        const domain = (domainExp && domainExp[1]) || '';
+        if (domain.startsWith('www.')) {
+            return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
+        }
+        return domain;
     }),
 
     actions: {


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/397

The default newsletter/support email address for a site is currently setup as noreply@DOMAIN , which means for a custom domain setup with www the email address becomes noreply@www.somesite.com which is not the expected behavior.

Note: This fix only removes `www` subdomain from addresses and no other subdomains
