### PR TITLE
 🐛 Fixed host limit error when resending a pending invite

### DIFF
--- a/app/models/invite.js
+++ b/app/models/invite.js
@@ -24,9 +24,12 @@ export default Model.extend({
 
         let inviteUrl = this.get('ghostPaths.url').api('invites');
 
-        return this.ajax.post(inviteUrl, {
-            data: JSON.stringify({invites: [inviteData]}),
-            contentType: 'application/json'
-        });
+        return this.ajax.del(`${inviteUrl}${this.get('id')}`)
+            .then(() => {
+                return this.ajax.post(inviteUrl, {
+                    data: JSON.stringify({invites: [inviteData]}),
+                    contentType: 'application/json'
+                });
+            });
     }
 });

--- a/tests/unit/models/invite-test.js
+++ b/tests/unit/models/invite-test.js
@@ -19,10 +19,16 @@ describe('Unit: Model: invite', function () {
             server.shutdown();
         });
 
-        it('resend hits correct endpoint', function () {
+        it('resend hits correct endpoints', function () {
             let store = this.owner.lookup('service:store');
-            let model = store.createRecord('invite');
+            let model = store.createRecord('invite', {
+                id: 42
+            });
             let role;
+
+            server.delete(`${ghostPaths().apiRoot}/invites/42`, function () {
+                return [204, {}, '{}'];
+            });
 
             server.post(`${ghostPaths().apiRoot}/invites/`, function () {
                 return [200, {}, '{}'];
@@ -38,7 +44,7 @@ describe('Unit: Model: invite', function () {
             expect(
                 server.handledRequests.length,
                 'number of requests'
-            ).to.equal(1);
+            ).to.equal(2);
 
             let [lastRequest] = server.handledRequests;
             let requestBody = JSON.parse(lastRequest.requestBody);

--- a/tests/unit/models/invite-test.js
+++ b/tests/unit/models/invite-test.js
@@ -1,5 +1,6 @@
 import Pretender from 'pretender';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
@@ -19,7 +20,7 @@ describe('Unit: Model: invite', function () {
             server.shutdown();
         });
 
-        it('resend hits correct endpoints', function () {
+        it('resend hits correct endpoints', async function () {
             let store = this.owner.lookup('service:store');
             let model = store.createRecord('invite', {
                 id: 42
@@ -40,6 +41,7 @@ describe('Unit: Model: invite', function () {
                 model.set('role', role);
                 model.resend();
             });
+            await wait();
 
             expect(
                 server.handledRequests.length,

--- a/tests/unit/models/invite-test.js
+++ b/tests/unit/models/invite-test.js
@@ -47,8 +47,7 @@ describe('Unit: Model: invite', function () {
                 server.handledRequests.length,
                 'number of requests'
             ).to.equal(2);
-
-            let [lastRequest] = server.handledRequests;
+            let [, lastRequest] = server.handledRequests;
             let requestBody = JSON.parse(lastRequest.requestBody);
             let [invite] = requestBody.invites;
 


### PR DESCRIPTION
 refs https://github.com/TryGhost/Team/issues/587

 - It was not possible to invite a new Contributor to a site that has reached its limit
 - This fix divides the resend invite action into two separate steps: 1. Deleting existing invite 2. Creating a new one for the same data
 - It was hitting the limit because the permissions were correctly checking for "add" action being executed when the limit of invites/staff users was already used up. By removing existing invite we mimic the behavior the server would do for us anyway (https://github.com/TryGhost/Ghost/blob/2111992dd42cd9d9400eebea52006d023b4b19b3/core/server/services/invites/invites.js#L18-L22)


@rishabhgrg I struggled to figure out why the test for the invites was failing and not picking up the second request. I'm assuming the "run" block in which the `invite.resend` is placed doesn't wait till the second request to complete :thinking: Can you help with this? You have a lot more experience with Ember and it's test, so thought I'd reach out!