### PR TITLE
Updated setting model for new `members_signup_access` setting

### DIFF
--- a/app/controllers/settings/members-access.js
+++ b/app/controllers/settings/members-access.js
@@ -44,19 +44,17 @@ export default class MembersAccessController extends Controller {
 
     @action
     setDefaultContentVisibility(value) {
-        this.settings.set('defaultContentVisibility', value);
+        if (this.settings.get('membersSignupAccess') !== 'none') {
+            this.settings.set('defaultContentVisibility', value);
+        }
     }
 
     @action
     setSignupAccess(value) {
-        switch (value) {
-        case 'all':
-            this.settings.set('membersAllowFreeSignup', true);
-            break;
-
-        case 'invite':
-            this.settings.set('membersAllowFreeSignup', false);
-            break;
+        this.settings.set('membersSignupAccess', value);
+        if (value === 'none') {
+            this.settings.set('defaultContentVisibility', 'public');
+            this.postAccessOpen = true;
         }
     }
 

--- a/app/controllers/settings/members-access.js
+++ b/app/controllers/settings/members-access.js
@@ -8,7 +8,7 @@ export default class MembersAccessController extends Controller {
     @service settings;
 
     @tracked showLeaveSettingsModal = false;
-    @tracked subscriptionAccessOpen = false;
+    @tracked signupAccessOpen = false;
     @tracked postAccessOpen = false;
 
     leaveRoute(transition) {
@@ -33,8 +33,8 @@ export default class MembersAccessController extends Controller {
     }
 
     @action
-    toggleSubscriptionAccess() {
-        this.subscriptionAccessOpen = !this.subscriptionAccessOpen;
+    toggleSignupAccess() {
+        this.signupAccessOpen = !this.signupAccessOpen;
     }
 
     @action
@@ -48,9 +48,9 @@ export default class MembersAccessController extends Controller {
     }
 
     @action
-    setSubscriptionAccess(value) {
+    setSignupAccess(value) {
         switch (value) {
-        case 'anyone':
+        case 'all':
             this.settings.set('membersAllowFreeSignup', true);
             break;
 

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import Model, {attr} from '@ember-data/model';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import {computed} from '@ember/object';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'setting',
@@ -52,7 +53,7 @@ export default Model.extend(ValidationEngine, {
      * Members settings
      */
     defaultContentVisibility: attr('string'),
-    membersAllowFreeSignup: attr('boolean'),
+    membersSignupAccess: attr('string'),
     membersFromAddress: attr('string'),
     membersSupportAddress: attr('string'),
     membersReplyAddress: attr('string'),
@@ -74,5 +75,18 @@ export default Model.extend(ValidationEngine, {
     newsletterShowHeader: attr('boolean'),
     newsletterBodyFontCategory: attr('string'),
     newsletterShowBadge: attr('boolean'),
-    newsletterFooterContent: attr('string')
+    newsletterFooterContent: attr('string'),
+
+    // TODO: remove when Access screen with "Nobody" option is out of dev experiments
+    membersAllowFreeSignup: computed('membersSignupAccess', {
+        get() {
+            const signupAccess = this.membersSignupAccess;
+            return signupAccess === 'all' ? true : false;
+        },
+        set(key, allowFreeSignup) {
+            const signupAccess = allowFreeSignup ? 'all' : 'invite';
+            this.set('membersSignupAccess', signupAccess);
+            return allowFreeSignup;
+        }
+    })
 });

--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -49,6 +49,10 @@ input {
     color: var(--red);
 }
 
+.disabled-overlay {
+    pointer-events: none;
+    opacity: 0.5;
+}
 
 /* Form Groups
 /* ---------------------------------------------------------- */

--- a/app/templates/settings/members-access.hbs
+++ b/app/templates/settings/members-access.hbs
@@ -25,14 +25,14 @@
                         <h4 class="gh-expandable-title">Subscription access</h4>
                         <p class="gh-expandable-description">Who should be able to subscribe to your site?</p>
                     </div>
-                    <button type="button" class="gh-btn" {{on "click" this.toggleSubscriptionAccess}} data-test-toggle="subscription-access"><span>{{if this.subscriptionAccessOpen "Close" "Expand"}}</span></button>
+                    <button type="button" class="gh-btn" {{on "click" this.toggleSignupAccess}} data-test-toggle="subscription-access"><span>{{if this.subscriptionAccessOpen "Close" "Expand"}}</span></button>
                 </div>
                 <div class="gh-expandable-content">
-                    {{#liquid-if this.subscriptionAccessOpen}}
+                    {{#liquid-if this.signupAccessOpen}}
                         <div class="flex flex-column w-50">
                             <div
                                 class="gh-radio {{if this.settings.membersAllowFreeSignup "active"}}"
-                                {{on "click" (fn this.setSubscriptionAccess "anyone")}}
+                                {{on "click" (fn this.setSignupAccess "all")}}
                             >
                                 <div class="gh-radio-button"></div>
                                 <div class="gh-radio-content">
@@ -43,7 +43,7 @@
 
                             <div
                                 class="gh-radio {{if (not this.settings.membersAllowFreeSignup) "active"}}"
-                                {{on "click" (fn this.setSubscriptionAccess "invite")}}
+                                {{on "click" (fn this.setSignupAccess "invite")}}
                             >
                                 <div class="gh-radio-button"></div>
                                 <div class="gh-radio-content">

--- a/app/templates/settings/members-access.hbs
+++ b/app/templates/settings/members-access.hbs
@@ -31,7 +31,7 @@
                     {{#liquid-if this.signupAccessOpen}}
                         <div class="flex flex-column w-50">
                             <div
-                                class="gh-radio {{if this.settings.membersAllowFreeSignup "active"}}"
+                                class="gh-radio {{if (eq this.settings.membersSignupAccess "all") "active"}}"
                                 {{on "click" (fn this.setSignupAccess "all")}}
                             >
                                 <div class="gh-radio-button"></div>
@@ -42,13 +42,24 @@
                             </div>
 
                             <div
-                                class="gh-radio {{if (not this.settings.membersAllowFreeSignup) "active"}}"
+                                class="gh-radio {{if (eq this.settings.membersSignupAccess "invite") "active"}}"
                                 {{on "click" (fn this.setSignupAccess "invite")}}
                             >
                                 <div class="gh-radio-button"></div>
                                 <div class="gh-radio-content">
                                     <div class="gh-radio-label">Only people I invite</div>
                                     <small class="midgrey">People can sign in from your site but won't be able to sign up</small>
+                                </div>
+                            </div>
+
+                            <div
+                                class="gh-radio {{if (eq this.settings.membersSignupAccess "none") "active"}}"
+                                {{on "click" (fn this.setSignupAccess "none")}}
+                            >
+                                <div class="gh-radio-button"></div>
+                                <div class="gh-radio-content">
+                                    <div class="gh-radio-label">Nobody</div>
+                                    <small class="midgrey">No one will be able to subscribe or sign in</small>
                                 </div>
                             </div>
                         </div>
@@ -79,26 +90,26 @@
                                 <small class="midgrey">All site visitors to your site, no login required</small></div>
                             </div>
                         </div>
-
-                        <div
-                            class="gh-radio {{if (eq this.settings.defaultContentVisibility "members") "active"}}"
-                            {{on "click" (fn this.setDefaultContentVisibility "members")}}
-                        >
-                            <div class="gh-radio-button"></div>
-                            <div class="gh-radio-content">
-                                <div class="gh-radio-label">Members only<br>
-                                <small class="midgrey">All logged-in members</small></div>
+                        <div class="{{if (eq this.settings.membersSignupAccess "none") "disabled-overlay"}}">
+                            <div
+                                class="gh-radio {{if (eq this.settings.defaultContentVisibility "members") "active"}}"
+                                {{on "click" (fn this.setDefaultContentVisibility "members")}}
+                            >
+                                <div class="gh-radio-button"></div>
+                                <div class="gh-radio-content">
+                                    <div class="gh-radio-label">Members only<br>
+                                    <small class="midgrey">All logged-in members</small></div>
+                                </div>
                             </div>
-                        </div>
-
-                        <div
-                            class="gh-radio {{if (eq this.settings.defaultContentVisibility "paid") "active"}}"
-                            {{on "click" (fn this.setDefaultContentVisibility "paid")}}
-                        >
-                            <div class="gh-radio-button"></div>
-                            <div class="gh-radio-content">
-                                <div class="gh-radio-label">Paid-members only<br>
-                                <small class="midgrey">Only logged-in members with an active Stripe subscription</small></div>
+                            <div
+                                class="gh-radio {{if (eq this.settings.defaultContentVisibility "paid") "active"}}"
+                                {{on "click" (fn this.setDefaultContentVisibility "paid")}}
+                            >
+                                <div class="gh-radio-button"></div>
+                                <div class="gh-radio-content">
+                                    <div class="gh-radio-label">Paid-members only<br>
+                                    <small class="midgrey">Only logged-in members with an active Stripe subscription</small></div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/579
requires https://github.com/TryGhost/Ghost/pull/12886

- renamed `membersAllowFreeSignup` to `membersSignupAccess` and changed type to match new setting
- added `membersAllowFreeSignup` computed property to map to the new setting to avoid having to migrate code elsewhere that will be removed once the new options are out of developer experiments
