### PR TITLE
Added limit check before adding new integration

### DIFF
--- a/app/components/modal-upgrade-custom-integrations-host-limit.hbs
+++ b/app/components/modal-upgrade-custom-integrations-host-limit.hbs
@@ -1,0 +1,20 @@
+<header class="modal-header" data-test-modal="delete-user">
+    <h1>Upgrade to enable custom integrations</h1>
+</header>
+<button class="close" title="Close" {{on "click" this.closeModal}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
+
+<div class="modal-body">
+    <p>
+        {{html-safe this.model.message}}
+    </p>
+</div>
+
+<div class="modal-footer">
+    <button {{on "click" this.closeModal}} class="gh-btn" data-test-button="cancel-upgrade">
+        <span>Cancel</span>
+    </button>
+
+    <button {{on "click" (action "upgrade")}} class="gh-btn gh-btn-black" data-test-button="upgrade-plan">
+        <span>Upgrade my plan</span>
+    </button>
+</div>

--- a/app/components/modal-upgrade-custom-integrations-host-limit.js
+++ b/app/components/modal-upgrade-custom-integrations-host-limit.js
@@ -1,0 +1,12 @@
+import ModalComponent from 'ghost-admin/components/modal-base';
+import {inject as service} from '@ember/service';
+
+export default ModalComponent.extend({
+    router: service(),
+
+    actions: {
+        upgrade: function () {
+            this.router.transitionTo('pro');
+        }
+    }
+});

--- a/app/controllers/integrations/new.js
+++ b/app/controllers/integrations/new.js
@@ -1,8 +1,18 @@
 import Controller from '@ember/controller';
 import {alias} from '@ember/object/computed';
+import {computed} from '@ember/object';
 
 export default Controller.extend({
-    integration: alias('model'),
+    integration: alias('model.integration'),
+    hostLimitError: alias('model.hostLimitError'),
+
+    showUpgradeModal: computed('hostLimitError', function () {
+        if (this.hostLimitError) {
+            return true;
+        }
+
+        return false;
+    }),
 
     actions: {
         save() {

--- a/app/routes/integrations/new.js
+++ b/app/routes/integrations/new.js
@@ -1,8 +1,27 @@
+import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
+import {inject as service} from '@ember/service';
 
 export default Route.extend({
+    limit: service(),
+
     model() {
-        return this.store.createRecord('integration');
+        if (this.limit.limiter
+            && this.limit.limiter.isLimited('customIntegrations')) {
+            return RSVP.hash({
+                integration: this.store.createRecord('integration'),
+                hostLimitError: this.limit.limiter.errorIfWouldGoOverLimit('customIntegrations')
+                    .then(() => null)
+                    .catch((error) => {
+                        return error;
+                    })
+            });
+        } else {
+            return RSVP.hash({
+                integration: this.store.createRecord('integration'),
+                hostLimitError: null
+            });
+        }
     },
 
     deactivate() {

--- a/app/templates/integrations/new.hbs
+++ b/app/templates/integrations/new.hbs
@@ -1,5 +1,14 @@
-<GhFullscreenModal @modal="new-integration"
-    @model={{this.integration}}
-    @confirm={{action "save"}}
-    @close={{action "cancel"}}
-    @modifier="action wide" />
+{{#if showUpgradeModal}}
+    <GhFullscreenModal @modal="upgrade-custom-integrations-host-limit"
+        @model={{hash
+            message=this.hostLimitError.message
+        }}
+        @close={{action "cancel"}}
+        @modifier="action wide" />
+{{else}}
+    <GhFullscreenModal @modal="new-integration"
+        @model={{this.integration}}
+        @confirm={{action "save"}}
+        @close={{action "cancel"}}
+        @modifier="action wide" />
+{{/if}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/599

- Previously user received genetic limit error after putting in integration name and clicking "create" button. This created a little frustrating experience.
- The updated flow does the check before loading the integration modal, so the user receives communication about needed upgrade before doing any work

@kevinansfield to detect when the limit on integrations is reached I've made integrations.new router return multiple models. Wasn't able to come up with any nicer solution, so was wondering if this is an ok solution or could be done nicer?  Also, would appreciate feedback on the rest of ember code I've added :raised_hands: 