### PR TITLE
✨ Added label and product options for email recipients

### DIFF
--- a/app/adapters/post.js
+++ b/app/adapters/post.js
@@ -7,7 +7,13 @@ export default ApplicationAdapter.extend({
         let parsedUrl = new URL(url);
 
         if (snapshot && snapshot.adapterOptions && snapshot.adapterOptions.sendEmailWhenPublished) {
-            parsedUrl.searchParams.append('email_recipient_filter', snapshot.adapterOptions.sendEmailWhenPublished);
+            let emailRecipientFilter = snapshot.adapterOptions.sendEmailWhenPublished;
+
+            if (emailRecipientFilter === 'status:free,status:-free') {
+                emailRecipientFilter = 'all';
+            }
+
+            parsedUrl.searchParams.append('email_recipient_filter', emailRecipientFilter);
         }
 
         return parsedUrl.toString();

--- a/app/components/gh-members-segment-count.js
+++ b/app/components/gh-members-segment-count.js
@@ -28,5 +28,6 @@ export default class GhMembersSegmentCountComponent extends Component {
 
         const members = yield this.store.query('member', {limit: 1, filter: this.args.segment});
         this.segmentTotal = members.meta.pagination.total;
+        this.args.onSegmentCountChange?.(this.segmentTotal);
     }
 }

--- a/app/components/gh-members-segment-select.hbs
+++ b/app/components/gh-members-segment-select.hbs
@@ -12,4 +12,7 @@
     {{option.name}}
 </GhTokenInput>
 
-<GhMembersSegmentCount @segment={{@segment}} />
+<GhMembersSegmentCount
+    @segment={{@segment}}
+    @onSegmentCountChange={{@onSegmentCountChange}}
+/>

--- a/app/components/gh-members-segment-select.js
+++ b/app/components/gh-members-segment-select.js
@@ -57,6 +57,50 @@ export default class GhMembersSegmentSelect extends Component {
             class: 'segment-status'
         }];
 
+        // fetch all labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
+        // TODO: add `include: 'count.members` to query once API is fixed
+        const labels = yield this.store.query('label', {limit: 'all'});
+
+        if (labels.length > 0) {
+            const labelsGroup = {
+                groupName: 'Labels',
+                options: []
+            };
+
+            labels.forEach((label) => {
+                labelsGroup.options.push({
+                    name: label.name,
+                    segment: `label:${label.slug}`,
+                    count: label.count?.members,
+                    class: 'segment-label'
+                });
+            });
+
+            options.push(labelsGroup);
+        }
+
+        // fetch all products w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
+        // TODO: add `include: 'count.members` to query once API supports
+        const products = yield this.store.query('product', {limit: 'all'});
+
+        if (products.length > 0) {
+            const productsGroup = {
+                groupName: 'Products',
+                options: []
+            };
+
+            products.forEach((product) => {
+                productsGroup.options.push({
+                    name: product.name,
+                    segment: `product:${product.slug}`,
+                    count: product.count?.members,
+                    class: 'segment-product'
+                });
+            });
+
+            options.push(productsGroup);
+        }
+
         this.options = options;
     }
 }

--- a/app/components/gh-publishmenu-draft.hbs
+++ b/app/components/gh-publishmenu-draft.hbs
@@ -41,7 +41,8 @@
                         <div class="form-group">
                             <GhMembersSegmentSelect
                                 @segment={{this.recipientsSegment}}
-                                @onChange={{action "setSendEmailWhenPublished"}}
+                                @onChange={{this.setSendEmailWhenPublished}}
+                                @onSegmentCountChange={{this.updateMemberCount}}
                                 @renderInPlace={{true}}
                             />
                         </div>

--- a/app/components/gh-publishmenu-draft.js
+++ b/app/components/gh-publishmenu-draft.js
@@ -4,20 +4,6 @@ import {computed} from '@ember/object';
 import {isEmpty} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
-const MEMBERS_SEGMENT_MAP = [{
-    name: 'all',
-    segment: 'status:free,status:-free'
-}, {
-    name: 'free',
-    segment: 'status:free'
-}, {
-    name: 'paid',
-    segment: 'status:-free'
-}, {
-    name: 'none',
-    segment: null
-}];
-
 export default Component.extend({
     feature: service(),
     settings: service(),
@@ -86,11 +72,6 @@ export default Component.extend({
 
             post.set('publishedAtBlogTime', time);
             return post.validate();
-        },
-
-        setSendEmailWhenPublished(segment) {
-            const segmentName = MEMBERS_SEGMENT_MAP.findBy('segment', segment).name;
-            this.setSendEmailWhenPublished(segmentName);
         }
     },
 

--- a/app/components/gh-publishmenu.hbs
+++ b/app/components/gh-publishmenu.hbs
@@ -16,7 +16,7 @@
                 @saveType={{this.saveType}}
                 @isClosing={{this.isClosing}}
                 @canSendEmail={{this.canSendEmail}}
-                @recipientsSegment={{this.recipientsSegment}}
+                @recipientsSegment={{this.sendEmailWhenPublished}}
                 @setSaveType={{action "setSaveType"}}
                 @setTypedDateError={{action (mut this.typedDateError)}}
                 @isSendingEmailLimited={{this.isSendingEmailLimited}}
@@ -29,7 +29,8 @@
                 @setSaveType={{action "setSaveType"}}
                 @setTypedDateError={{action (mut this.typedDateError)}}
                 @canSendEmail={{this.canSendEmail}}
-                @recipientsSegment={{this.recipientsSegment}}
+                @recipientsSegment={{this.sendEmailWhenPublished}}
+                @updateMemberCount={{action "updateMemberCount"}}
                 @setSendEmailWhenPublished={{action "setSendEmailWhenPublished"}}
                 @isSendingEmailLimited={{this.isSendingEmailLimited}}
                 @sendingEmailLimitError={{this.sendingEmailLimitError}} />

--- a/app/components/modal-confirm-email-send.hbs
+++ b/app/components/modal-confirm-email-send.hbs
@@ -13,15 +13,18 @@
             <p>
                 Your post will be delivered to
                 <strong>
-                    {{#if (eq this.model.sendEmailWhenPublished 'paid')}}
+                    {{#if (eq this.model.sendEmailWhenPublished 'status:-free')}}
                         {{!-- TODO: remove editor fallback once editors can query member counts --}}
-                        {{if this.session.user.isEditor "all paid members" (gh-pluralize this.paidMemberCount "paid member")}}
-                    {{else if (eq this.model.sendEmailWhenPublished 'free')}}
+                        {{if this.session.user.isEditor "all paid members" (gh-pluralize this.model.memberCount "paid member")}}
+                    {{else if (eq this.model.sendEmailWhenPublished 'status:free')}}
                         {{!-- TODO: remove editor fallback once editors can query member counts --}}
-                        {{if this.session.user.isEditor "all free members" (gh-pluralize this.freeMemberCount "free member")}}
-                    {{else}}
+                        {{if this.session.user.isEditor "all free members" (gh-pluralize this.model.memberCount "free member")}}
+                    {{else if (eq this.model.sendEmailWhenPublished 'status:free,status:-free')}}
                         {{!-- TODO: remove editor fallback once editors can query member counts --}}
                         {{if this.session.user.isEditor "all members" (gh-pluralize this.model.memberCount "member")}}
+                    {{else}}
+                        {{!-- TODO: remove editor fallback once editors can query member counts --}}
+                        {{if this.session.user.isEditor "a custom members segment" (gh-pluralize this.model.memberCount "member")}}
                     {{/if}}
                 </strong>
                 and will be published on your site{{#if this.model.isScheduled}} at the scheduled time{{/if}}. Sound good?

--- a/app/components/settings/default-email-recipients.hbs
+++ b/app/components/settings/default-email-recipients.hbs
@@ -64,6 +64,21 @@
                         <div class="gh-radio-label">Paid members</div>
                     </div>
                 </div>
+                <div
+                    class="gh-radio {{if this.isSegmentSelected "active"}}"
+                    {{on "click" (fn this.setDefaultEmailRecipients "segment")}}
+                >
+                    <div class="gh-radio-button"></div>
+                    <div class="gh-radio-content">
+                        <div class="gh-radio-label">Specific segment:</div>
+                        <div class="gh-radio-desc">
+                            <GhMembersSegmentSelect
+                                @segment={{this.settings.editorDefaultEmailRecipientsFilter}}
+                                @onChange={{this.setDefaultEmailRecipientsFilter}}
+                            />
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
         {{/liquid-if}}

--- a/app/components/settings/default-email-recipients.js
+++ b/app/components/settings/default-email-recipients.js
@@ -62,6 +62,8 @@ export default class SettingsDefaultEmailRecipientsComponent extends Component {
 
     @action
     setDefaultEmailRecipients(value) {
+        this.segmentSelected = false;
+
         if (['disabled', 'visibility'].includes(value)) {
             this.settings.set('editorDefaultEmailRecipients', value);
             return;
@@ -83,6 +85,15 @@ export default class SettingsDefaultEmailRecipientsComponent extends Component {
             this.settings.set('editorDefaultEmailRecipientsFilter', 'status:-free');
         }
 
+        if (value === 'segment') {
+            this.segmentSelected = true;
+        }
+
         this.settings.set('editorDefaultEmailRecipients', 'filter');
+    }
+
+    @action
+    setDefaultEmailRecipientsFilter(filter) {
+        this.settings.set('editorDefaultEmailRecipientsFilter', filter);
     }
 }

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -105,7 +105,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     updatedBy: attr('number'),
     url: attr('string'),
     uuid: attr('string'),
-    emailRecipientFilter: attr('string', {defaultValue: 'none'}),
+    emailRecipientFilter: attr('members-segment-string', {defaultValue: null}),
 
     authors: hasMany('user', {embedded: 'always', async: false}),
     createdBy: belongsTo('user', {async: true}),
@@ -152,7 +152,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     isPage: equal('displayName', 'page'),
 
     willEmail: computed('emailRecipientFilter', function () {
-        return this.emailRecipientFilter !== 'none';
+        return this.emailRecipientFilter !== null;
     }),
 
     previewUrl: computed('uuid', 'ghostPaths.url', 'config.blogUrl', function () {

--- a/app/styles/components/power-select.css
+++ b/app/styles/components/power-select.css
@@ -268,6 +268,26 @@
     fill: var(--blue);
 }
 
+.token-segment-label {
+    background: color-mod(var(--green) alpha(0.1));
+    color: var(--green);
+}
+
+.token-segment-label svg path {
+    stroke: var(--green);
+    fill: var(--green);
+}
+
+.token-segment-product {
+    background: color-mod(var(--purple) alpha(0.1));
+    color: var(--purple);
+}
+
+.token-segment-product svg path {
+    stroke: var(--purple);
+    fill: var(--purple);
+}
+
 /* Inside settings / Mailgun region */
 /* TODO: make these general styles? */
 

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -49,8 +49,7 @@
                                 @postStatus={{this.post.status}}
                                 @saveTask={{this.save}}
                                 @setSaveType={{action "setSaveType"}}
-                                @onOpen={{action "cancelAutosave"}}
-                                @memberCount={{this.memberCount}} />
+                                @onOpen={{action "cancelAutosave"}} />
                         </div>
                     {{/if}}
                 {{/unless}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/581
requires https://github.com/TryGhost/Team/issues/12932

- added segment option and select to default newsletter recipients setting
- updated segment selector to fetch labels/products and show as options
- updated segment selector and count component to call an action when count changes so we can use it in the email confirmation modal
- removed usage and mapping of older `'none'`, `'all'`, `'free'`, and `'paid'` email recipient filter values