### PR TITLE
Fixed member details not loading

### DIFF
--- a/app/components/gh-member-settings-form-cp.js
+++ b/app/components/gh-member-settings-form-cp.js
@@ -32,7 +32,9 @@ export default class extends Component {
     get products() {
         let products = this.member.get('products') || [];
         let subscriptions = this.member.get('subscriptions') || [];
-        let subscriptionData = subscriptions.map((sub) => {
+        let subscriptionData = subscriptions.filter((sub) => {
+            return !!sub.price;
+        }).map((sub) => {
             return {
                 ...sub,
                 startDate: sub.start_date ? moment(sub.start_date).format('D MMM YYYY') : '-',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/660

We added a guard to not send price object in a subscription when the data is missing from DB. This can cause the member details page to fail with the missing price object, so this change adds a guard against subscriptions with missing price.

Note: This is only a short-term fix till we add a proper fix to cleanup the DB in the subsequent release.
