### PR TITLE
Handled product save failure on Stripe connect

### DIFF
--- a/app/components/gh-post-settings-menu/email.js
+++ b/app/components/gh-post-settings-menu/email.js
@@ -125,6 +125,7 @@ export default Component.extend({
                 if (email.status === 'failed') {
                     throw new EmailFailedError(email.error);
                 }
+                pollTimeout += RETRY_EMAIL_POLL_LENGTH;
             }
         }
 


### PR DESCRIPTION
no refs

We try and create new default prices soon after Stripe Connect is completed, but it might take couple of seconds for backend to have Stripe config ready and in the meanwhile saving a product with new prices will fail with 409 Conflict error as it will be unable to create prices on Stripe. This change allows re-attempting saving a product with new prices soon after connect in case of a STRIPE_NOT_CONFIGURED error so that the default prices can be created properly.
