### PR TITLE
Fixed portal previews flashing background

### DIFF
--- a/app/components/gh-site-iframe.hbs
+++ b/app/components/gh-site-iframe.hbs
@@ -3,6 +3,7 @@
     src={{this.srcUrl}}
     frameborder="0"
     allowtransparency="true"
+    {{did-insert this.attachMessageListener}}
     {{did-update this.resetSrcAttribute @guid}}
     {{on "load" this.onLoad}}
     ...attributes

--- a/app/components/modal-portal-settings.hbs
+++ b/app/components/modal-portal-settings.hbs
@@ -248,7 +248,7 @@
                     class="gh-portal-siteiframe"
                     @src={{this.portalPreviewUrl}}
                     @guid={{this.portalPreviewGuid}}
-                    @invisibleUntilLoaded={{true}} />
+                    @invisibleUntilLoaded="portal-ready" />
             </div>
 
         </div>

--- a/app/templates/settings/membership.hbs
+++ b/app/templates/settings/membership.hbs
@@ -58,7 +58,7 @@
                         <GhSiteIframe
                             @src={{this.portalPreviewUrl}}
                             @guid={{this.portalPreviewGuid}}
-                            @invisibleUntilLoaded={{true}}
+                            @invisibleUntilLoaded="portal-ready"
                             @onLoad={{this.portalPreviewLoaded}}
                             @onDestroyed={{this.portalPreviewDestroyed}} />
                     {{/if}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/701
requires Portal@1.4.2 or later

- changed `<GhSiteIframe @invisibleUntilLoaded>` to accept a string in place of a `true/false` value
    - if a string is passed then we'll set up a message event listener than listens for a `postMessage` from the iframe with data that matches the supplied string
- updated `<GhSiteIframe>` usage for portal previews to use `@invisibleUntilLoaded="portal-ready"` so they listen for a message event rather than displaying as soon as we get a load event
