### PR TITLE
Added animation to portal preview height

### DIFF
--- a/app/components/gh-site-iframe.hbs
+++ b/app/components/gh-site-iframe.hbs
@@ -3,6 +3,7 @@
     src={{this.srcUrl}}
     frameborder="0"
     allowtransparency="true"
+    scrolling="no"
     {{did-insert this.attachMessageListener}}
     {{did-update this.resetSrcAttribute @guid}}
     {{on "load" this.onLoad}}

--- a/app/controllers/settings/membership.js
+++ b/app/controllers/settings/membership.js
@@ -260,6 +260,9 @@ export default class MembersAccessController extends Controller {
                 return;
             }
 
+            portalIframe.contentWindow.document.body.style.overflow = 'hidden';
+            portalIframe.contentWindow.document.body.style['scrollbar-width'] = 'none';
+
             const portalContainer = portalIframe.contentWindow.document.querySelector('.gh-portal-popup-container');
             if (!portalContainer) {
                 return;

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -1645,6 +1645,7 @@ p.theme-validation-details {
     margin-bottom: 32px;
     border-radius: 5px;
     pointer-events: none;
+    transition: height 0.35s ease-in-out;
 }
 
 .gh-setting-members-portal-disabled {


### PR DESCRIPTION
no issue

- add CSS transition for height attribute of portal preview container
- before adjusting height of container, apply styles to portal preview nested iframe to prevent scrollbars from showing
