### PR TITLE
🐛 Fixed portal preview resize when using split front-end/admin URLs

### DIFF
--- a/app/components/gh-site-iframe.hbs
+++ b/app/components/gh-site-iframe.hbs
@@ -3,7 +3,7 @@
     src={{this.srcUrl}}
     frameborder="0"
     allowtransparency="true"
-    {{did-insert @onInserted}}
+    {{did-insert (optional @onInserted)}}
     {{did-insert this.attachMessageListener}}
     {{did-update this.resetSrcAttribute @guid}}
     {{on "load" this.onLoad}}

--- a/app/components/gh-site-iframe.hbs
+++ b/app/components/gh-site-iframe.hbs
@@ -3,6 +3,7 @@
     src={{this.srcUrl}}
     frameborder="0"
     allowtransparency="true"
+    {{did-insert @onInserted}}
     {{did-insert this.attachMessageListener}}
     {{did-update this.resetSrcAttribute @guid}}
     {{on "load" this.onLoad}}

--- a/app/components/gh-site-iframe.js
+++ b/app/components/gh-site-iframe.js
@@ -66,7 +66,7 @@ export default class GhSiteIframeComponent extends Component {
                 const originURL = new URL(event.origin);
 
                 if (originURL.origin === srcURL.origin) {
-                    if (event.data === this.args.invisibleUntilLoaded) {
+                    if (event.data === this.args.invisibleUntilLoaded || event.data.type === this.args.invisibleUntilLoaded) {
                         this.makeVisible.perform();
                     }
                 }

--- a/app/components/gh-site-iframe.js
+++ b/app/components/gh-site-iframe.js
@@ -62,6 +62,10 @@ export default class GhSiteIframeComponent extends Component {
     attachMessageListener() {
         if (typeof this.args.invisibleUntilLoaded === 'string') {
             this.messageListener = (event) => {
+                if (this.isDestroying || this.isDestroyed) {
+                    return;
+                }
+
                 const srcURL = new URL(this.srcUrl);
                 const originURL = new URL(event.origin);
 

--- a/app/controllers/settings/membership.js
+++ b/app/controllers/settings/membership.js
@@ -245,11 +245,13 @@ export default class MembersAccessController extends Controller {
 
     @action
     portalPreviewInserted(iframe) {
+        this.portalPreviewIframe = iframe;
+
         if (!this.portalMessageListener) {
             this.portalMessageListener = (event) => {
                 const resizeEvents = ['portal-ready', 'portal-preview-updated'];
                 if (resizeEvents.includes(event.data.type) && event.data.payload?.height) {
-                    iframe.parentNode.style.height = `${event.data.payload.height}px`;
+                    this.portalPreviewIframe.parentNode.style.height = `${event.data.payload.height}px`;
                 }
             };
 
@@ -259,6 +261,8 @@ export default class MembersAccessController extends Controller {
 
     @action
     portalPreviewDestroyed() {
+        this.portalPreviewIframe = null;
+
         if (this.portalMessageListener) {
             window.removeEventListener('message', this.portalMessageListener);
         }

--- a/app/controllers/settings/membership.js
+++ b/app/controllers/settings/membership.js
@@ -4,7 +4,6 @@ import {action} from '@ember/object';
 import {currencies, getCurrencyOptions, getSymbol} from 'ghost-admin/utils/currency';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
-import {timeout} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 const CURRENCIES = currencies.map((currency) => {

--- a/app/controllers/settings/membership.js
+++ b/app/controllers/settings/membership.js
@@ -249,6 +249,11 @@ export default class MembersAccessController extends Controller {
 
         if (!this.portalMessageListener) {
             this.portalMessageListener = (event) => {
+                // don't resize membership portal preview when events fire in customize portal modal
+                if (this.showPortalSettings) {
+                    return;
+                }
+
                 const resizeEvents = ['portal-ready', 'portal-preview-updated'];
                 if (resizeEvents.includes(event.data.type) && event.data.payload?.height) {
                     this.portalPreviewIframe.parentNode.style.height = `${event.data.payload.height}px`;

--- a/app/templates/settings/membership.hbs
+++ b/app/templates/settings/membership.hbs
@@ -59,7 +59,7 @@
                             scrolling="no"
                             @src={{this.portalPreviewUrl}}
                             @invisibleUntilLoaded="portal-ready"
-                            @onLoad={{this.portalPreviewLoaded}}
+                            @onInserted={{this.portalPreviewInserted}}
                             @onDestroyed={{this.portalPreviewDestroyed}} />
                     {{/if}}
                 </div>


### PR DESCRIPTION
no issue

- switched to listening to Portal's `message` events that now include a height
- removes need to reach into Portal preview iframe contents which is blocked by browser security when working cross-origin
