### PR TITLE
🐛 Fixed missing complimentary subscription add button

### DIFF
--- a/app/components/gh-member-settings-form-cp.js
+++ b/app/components/gh-member-settings-form-cp.js
@@ -31,7 +31,9 @@ export default class extends Component {
 
     get isAddComplimentaryAllowed() {
         let subscriptions = this.member.get('subscriptions') || [];
-        const hasZeroPriceSub = subscriptions.find((sub) => {
+        const hasZeroPriceSub = subscriptions.filter((sub) => {
+            return ['active', 'trialing', 'unpaid', 'past_due'].includes(sub.status);
+        }).find((sub) => {
             return !sub?.price?.amount;
         });
         return !hasZeroPriceSub;


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/81de2fe223e47255899523a113b63b1423c2de14
refs https://github.com/TryGhost/Team/issues/758

The "Add complimentary" subscription button in members does not show up when members already have an existing zero amount subscription. But this was incorrectly not taking into account active subscriptions and was applying the rule to canceled subscriptions. Since the `comped` behaviour changed in 4.6 which caused member's existing comp subscription to be canceled, this bug did not allow the comped subscription to be added back.
