### PR TITLE
✨ Added post feature image alt and caption support to editor

### DIFF
--- a/app/components/gh-koenig-editor.hbs
+++ b/app/components/gh-koenig-editor.hbs
@@ -5,18 +5,16 @@
         {{on "mousedown" this.trackMousedown}}
         {{on "mouseup" this.focusEditor}}
     >
-        {{#if (feature "featureImageMeta")}}
-            <GhEditorFeatureImage
-                @image={{@featureImage}}
-                @updateImage={{@setFeatureImage}}
-                @clearImage={{@clearFeatureImage}}
-                @alt={{@featureImageAlt}}
-                @updateAlt={{@setFeatureImageAlt}}
-                @caption={{@featureImageCaption}}
-                @updateCaption={{@setFeatureImageCaption}}
-                @forceButtonDisplay={{or this.titleIsHovered this.titleIsFocused}}
-            />
-        {{/if}}
+        <GhEditorFeatureImage
+            @image={{@featureImage}}
+            @updateImage={{@setFeatureImage}}
+            @clearImage={{@clearFeatureImage}}
+            @alt={{@featureImageAlt}}
+            @updateAlt={{@setFeatureImageAlt}}
+            @caption={{@featureImageCaption}}
+            @updateCaption={{@setFeatureImageCaption}}
+            @forceButtonDisplay={{or this.titleIsHovered this.titleIsFocused}}
+        />
 
         <GhTextarea
             @class="gh-editor-title"

--- a/app/components/gh-post-settings-menu-labs.hbs
+++ b/app/components/gh-post-settings-menu-labs.hbs
@@ -9,15 +9,6 @@
                 <h4>{{capitalize this.post.displayName}} settings</h4>
             </div>
             <div class="settings-menu-content labs">
-                {{#unless (feature "featureImageMeta")}}
-                    <GhImageUploaderWithPreview
-                        @image={{this.post.featureImage}}
-                        @text={{concat "Upload " this.post.displayName " image"}}
-                        @allowUnsplash={{true}}
-                        @update={{action "setCoverImage"}}
-                        @remove={{action "clearCoverImage"}}
-                    />
-                {{/unless}}
                 <form>
                 <div class="form-group">
                     <label for="url">{{capitalize this.post.displayName}} URL</label>

--- a/app/components/gh-post-settings-menu.hbs
+++ b/app/components/gh-post-settings-menu.hbs
@@ -8,15 +8,6 @@
                 </button>
             </div>
             <div class="settings-menu-content">
-                {{#unless (feature "featureImageMeta")}}
-                    <GhImageUploaderWithPreview
-                        @image={{this.post.featureImage}}
-                        @text={{concat "Upload " this.post.displayName " image"}}
-                        @allowUnsplash={{true}}
-                        @update={{action "setCoverImage"}}
-                        @remove={{action "clearCoverImage"}}
-                    />
-                {{/unless}}
                 <form>
                 <div class="form-group">
                     <label for="url">{{capitalize this.post.displayName}} URL</label>

--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -55,7 +55,6 @@ export default Service.extend({
     launchComplete: feature('launchComplete', {user: true}),
     matchHelper: feature('matchHelper'),
     multipleProducts: feature('multipleProducts', {developer: true}),
-    featureImageMeta: feature('featureImageMeta', {developer: true}),
     psmRedesign: feature('psmRedesign', {developer: true}),
 
     _user: null,

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -270,19 +270,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Feature image redesign with caption support</h4>
-                            <p class="gh-expandable-description">
-                               Moves feature image uploader to top of editor screen and adds alt/caption input.
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                           <GhFeatureFlag @flag="featureImageMeta" />
-                        </div>
-                    </div>
-                </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Post settings menu behaviour change</h4>
                             <p class="gh-expandable-description">
                                Switches post settings menu behaviour from a popover to a collapsible sidebar.


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/839

The feature image uploader in the post settings menu did not lend itself well to having additional fields so we've moved it into the main editor canvas. This allowed us to use the familiar caption/alt fields from image cards and to let the feature image feel more connected to the post's contents and part of the editing workflow.

---

- removed `featureImageMeta` labs flag
