### PR TITLE
Handle new visibility filter changes for post access

### DIFF
--- a/app/components/gh-members-segment-select.js
+++ b/app/components/gh-members-segment-select.js
@@ -59,15 +59,19 @@ export default class GhMembersSegmentSelect extends Component {
 
     @task
     *fetchOptionsTask() {
-        const options = yield [{
-            name: 'Free members',
-            segment: 'status:free',
-            class: 'segment-status-free'
-        }, {
-            name: 'Paid members',
-            segment: 'status:-free', // paid & comped
-            class: 'segment-status-paid'
-        }];
+        const options = yield [];
+
+        if (!this.args.hideDefaultSegments) {
+            options.push({
+                name: 'Free members',
+                segment: 'status:free',
+                class: 'segment-status-free'
+            }, {
+                name: 'Paid members',
+                segment: 'status:-free', // paid & comped
+                class: 'segment-status-paid'
+            });
+        }
 
         // fetch all labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
         // TODO: add `include: 'count.members` to query once API is fixed

--- a/app/components/gh-post-settings-menu.hbs
+++ b/app/components/gh-post-settings-menu.hbs
@@ -74,35 +74,22 @@
                     {{#if (feature "multipleProducts")}}
                         <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="visibility">
                             <label for="visibility-input">Post access</label>
-                            <div
-                                class="gh-radio {{if this.post.isPublic "active"}}"
-                                {{on "click" (action "setVisibility" "public")}}
-                            >
-                                <div class="gh-radio-button"></div>
-                                <div class="gh-radio-content">
-                                    <div class="gh-radio-label">Public</div>
-                                </div>
-                            </div>
-                            <div
-                                class="gh-radio {{if (not this.post.isPublic) "active"}}"
-                                {{on "click" (action "setVisibility" this.post.visibilitySegment)}}
-                            >
-                                <div class="gh-radio-button"></div>
-                                <div class="gh-radio-content">
-                                    <div class="gh-radio-label">Members-only</div>
-                                    <div class="gh-radio-desc">
-                                        <GhMembersSegmentSelect
-                                            @hideLabels={{true}}
-                                            @segment={{this.post.visibilitySegment}}
-                                            @onChange={{action "setVisibility"}}
-                                            @renderInPlace={{true}}
-                                            @hideOptionsWhenAllSelected={{true}}
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                            <GhErrorMessage @errors={{this.post.errors}} @property="visibility" class="no-selection" data-test-error="visibility" />
+                            <GhPsmVisibilityInput @post={{this.post}} @triggerId="visibility-input" />
                         </GhFormGroup>
+
+                        {{#if (eq this.post.visibility "filter")}}
+                            <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="visibilityFilter">
+                                <GhMembersSegmentSelect
+                                    @hideLabels={{true}}
+                                    @segment={{this.post.visibilitySegment}}
+                                    @onChange={{action "setVisibility"}}
+                                    @renderInPlace={{true}}
+                                    @hideDefaultSegments={{true}}
+                                    @hideOptionsWhenAllSelected={{true}}
+                                />
+                                <GhErrorMessage @errors={{this.post.errors}} @property="visibilityFilter" data-test-error="visibilityFilter" />
+                            </GhFormGroup>
+                        {{/if}}
                     {{else}}
                         <div class="form-group">
                             <label for="visibility-input">Post access</label>

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -138,10 +138,11 @@ export default Component.extend({
         },
 
         async setVisibility(segment) {
-            this.post.set('visibility', segment);
+            this.post.set('visibilityFilter', segment);
             try {
                 await this.post.validate({property: 'visibility'});
-                if (this.post.changedAttributes().visibility) {
+                await this.post.validate({property: 'visibilityFilter'});
+                if (this.post.changedAttributes().visibilityFilter) {
                     await this.savePostTask.perform();
                 }
             } catch (e) {

--- a/app/components/gh-psm-visibility-input.js
+++ b/app/components/gh-psm-visibility-input.js
@@ -11,6 +11,7 @@ const VISIBILITIES = [
 export default Component.extend({
 
     settings: service(),
+    feature: service(),
 
     // public attrs
     post: null,
@@ -22,11 +23,19 @@ export default Component.extend({
     init() {
         this._super(...arguments);
         this.availableVisibilities = VISIBILITIES;
+        if (this.feature.get('multipleProducts')) {
+            this.availableVisibilities.push(
+                {label: 'A segment', name: 'filter'}
+            );
+        }
     },
 
     actions: {
         updateVisibility(newVisibility) {
             this.post.set('visibility', newVisibility);
+            if (newVisibility !== 'filter') {
+                this.post.set('visibilityFilter', null);
+            }
         }
     }
 });

--- a/app/components/settings/members-default-post-access.hbs
+++ b/app/components/settings/members-default-post-access.hbs
@@ -23,4 +23,16 @@
             </div>
         </div>
     </PowerSelect>
+    {{#if this.hasVisibilityFilter}}
+        <div class="mt2">
+            <GhMembersSegmentSelect
+                @hideLabels={{true}}
+                @segment={{this.settings.defaultContentVisibility}}
+                @onChange={{action "setVisibility"}}
+                @renderInPlace={{true}}
+                @hideDefaultSegments={{true}}
+                @hideOptionsWhenAllSelected={{true}}
+            />
+        </div>
+    {{/if}}
 </div>

--- a/app/components/settings/members-default-post-access.js
+++ b/app/components/settings/members-default-post-access.js
@@ -4,9 +4,10 @@ import {inject as service} from '@ember/service';
 
 export default class SettingsMembersDefaultPostAccess extends Component {
     @service settings;
+    @service feature;
 
     get options() {
-        return [{
+        const defaultOptions = [{
             name: 'Public',
             description: 'All site visitors to your site, no login required',
             value: 'public',
@@ -25,20 +26,47 @@ export default class SettingsMembersDefaultPostAccess extends Component {
             icon: 'members-paid',
             icon_color: 'pink'
         }];
+        if (this.feature.get('multipleProducts')) {
+            defaultOptions.push({
+                name: 'A segment',
+                description: 'Members with any of the selected products',
+                value: 'filter',
+                icon: 'members-paid',
+                icon_color: 'yellow'
+            });
+        }
+        return defaultOptions;
+    }
+
+    get hasVisibilityFilter() {
+        return this.feature.get('multipleProducts') && !['public', 'members', 'paid'].includes(this.settings.get('defaultContentVisibility'));
     }
 
     get selectedOption() {
         if (this.settings.get('membersSignupAccess') === 'none') {
             return this.options.find(o => o.value === 'public');
         }
-
+        if (!['public', 'members', 'paid'].includes(this.settings.get('defaultContentVisibility'))) {
+            return this.options.find(o => o.value === 'filter');
+        }
         return this.options.find(o => o.value === this.settings.get('defaultContentVisibility'));
+    }
+
+    @action
+    setVisibility(segment) {
+        if (segment) {
+            this.settings.set('defaultContentVisibility', segment);
+        }
     }
 
     @action
     setDefaultContentVisibility(option) {
         if (this.settings.get('membersSignupAccess') !== 'none') {
-            this.settings.set('defaultContentVisibility', option.value);
+            if (option.value === 'filter') {
+                this.settings.set('defaultContentVisibility', '');
+            } else {
+                this.settings.set('defaultContentVisibility', option.value);
+            }
         }
     }
 }

--- a/app/controllers/settings/membership.js
+++ b/app/controllers/settings/membership.js
@@ -316,6 +316,13 @@ export default class MembersAccessController extends Controller {
 
     @task({drop: true})
     *saveSettingsTask(options) {
+        if (!this.settings.get('defaultContentVisibility')) {
+            const oldValue = this.settings.changedAttributes().defaultContentVisibility?.[0];
+            if (oldValue) {
+                this.settings.set('defaultContentVisibility', oldValue);
+            }
+        }
+
         if (!this.feature.get('multipleProducts')) {
             yield this.validateStripePlans({updatePortalPreview: false});
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -93,6 +93,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     emailSubject: attr('string'),
     html: attr('string'),
     visibility: attr('string'),
+    visibilityFilter: attr('string'),
     metaDescription: attr('string'),
     metaTitle: attr('string'),
     mobiledoc: attr('json-string', {defaultValue: () => JSON.parse(JSON.stringify(BLANK_DOC))}),
@@ -175,7 +176,7 @@ export default Model.extend(Comparable, ValidationEngine, {
         return this.visibility === 'public' ? true : false;
     }),
 
-    visibilitySegment: computed('visibility', 'isPublic', function () {
+    visibilitySegment: computed('visibility', 'visibilityFilter', 'isPublic', function () {
         if (this.isPublic) {
             return this.settings.get('defaultContentVisibility') === 'paid' ? 'status:-free' : 'status:free,status:-free';
         } else {
@@ -184,6 +185,9 @@ export default Model.extend(Comparable, ValidationEngine, {
             }
             if (this.visibility === 'paid') {
                 return 'status:-free';
+            }
+            if (this.visibility === 'filter') {
+                return this.visibilityFilter;
             }
             return this.visibility;
         }

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -45,6 +45,12 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
 
         if (json.visibility === null) {
             delete json.visibility;
+            delete json.visibility_filter;
+        }
+
+        if (json.visibility === 'filter' && json.visibility_filter === null) {
+            delete json.visibility;
+            delete json.visibility_filter;
         }
 
         return json;

--- a/app/validators/post.js
+++ b/app/validators/post.js
@@ -74,6 +74,13 @@ export default BaseValidator.create({
         }
     },
 
+    visibilityFilter(model) {
+        if (isBlank(model.visibilityFilter) && !isBlank(model.visibility) && model.visibility === 'filter' && !model.isNew) {
+            model.errors.add('visibilityFilter', 'A members group must be selected for members-only posts');
+            this.invalidate();
+        }
+    },
+
     codeinjectionFoot(model) {
         if (!validator.isLength(model.codeinjectionFoot || '', 0, 65535)) {
             model.errors.add('codeinjectionFoot', 'Footer code cannot be longer than 65535 characters.');

--- a/tests/integration/components/gh-psm-visibility-input-test.js
+++ b/tests/integration/components/gh-psm-visibility-input-test.js
@@ -37,7 +37,8 @@ describe('Integration: Component: gh-psm-visibility-input', function () {
         await fillIn('select', 'paid');
         await blur('select');
 
-        expect(setVisibility.calledOnce).to.be.true;
+        expect(setVisibility.calledTwice).to.be.true;
         expect(setVisibility.calledWith('visibility', 'paid')).to.be.true;
+        expect(setVisibility.calledWith('visibilityFilter', null)).to.be.true;
     });
 });


### PR DESCRIPTION
With multiple products we'll re-enable segmentation by product for posts, which also means we need to add a new option to the default post access setting in Membership settings. This PR handles the new segment for post access behind flag on both post settings and membership settings.

Note: PR is waiting on successful tests for merge