### PR TITLE
Minor typo fixes in members list filtering and query

### DIFF
--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -297,7 +297,7 @@ export default class MembersController extends Controller {
             || label !== this._lastLabel
             || paidParam !== this._lastPaidParam
             || searchParam !== this._lastSearchParam
-            || orderParam !== this._orderParam
+            || orderParam !== this._lastOrderParam
             || filterParam !== this._lastFilterParam;
         this._lastLabel = label;
         this._lastPaidParam = paidParam;

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -156,7 +156,7 @@ export default class MembersController extends Controller {
 
         let filters = [];
 
-        filters.concat(extraFilters);
+        filters = filters.concat(extraFilters);
 
         if (label) {
             filters.push(`label:'${label}'`);


### PR DESCRIPTION
Fixes minor typos in members list code -

- Fixed created_at filter not applied on members list query
- Fixed incorrect order param comparison in force reload