### PR TITLE
Removed empty filter param on members list

### DIFF
--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -170,7 +170,7 @@ export default class MembersController extends Controller {
             }
         }
 
-        if (filterParam) {
+        if (filterParam && this.feature.get('membersFiltering')) {
             filters.push(filterParam);
         }
 

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -44,7 +44,7 @@ export default class MembersController extends Controller {
     @tracked members = A([]);
     @tracked searchText = '';
     @tracked searchParam = '';
-    @tracked filterParam = '';
+    @tracked filterParam = null;
     @tracked paidParam = null;
     @tracked label = null;
     @tracked orderParam = null;


### PR DESCRIPTION
no refs

- removes empty filter param from url to avoid showing empty params on url

Note: PR to fix failing members list tests, will merge on ✔️ 
