### PR TITLE
🐛 Fixed validation error when saving pages in admin area

### DIFF
--- a/app/serializers/page.js
+++ b/app/serializers/page.js
@@ -8,6 +8,7 @@ export default PostSerializer.extend({
         delete json.email_subject;
         delete json.send_email_when_published;
         delete json.email_recipient_filter;
+        delete json.email_only;
         delete json.email_id;
         delete json.email;
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/998

- posts have a new `email_only` property for an alpha feature but that is not a valid property for pages
- our pages model and serializers currently inherit from the post model/serializer so when saving the new property is triggering a "no additional properties" validation error
- updating the pages serializer to remove the new property means the pages add/edit API requests are valid again
