### PR TITLE
Moved email-only selector to post publish menu

### DIFF
--- a/app/components/gh-distribution-action-select.hbs
+++ b/app/components/gh-distribution-action-select.hbs
@@ -1,0 +1,12 @@
+<span class="gh-select">
+    <OneWaySelect
+        @value={{this.distributionValue}}
+        @options={{this.availablePublishActions}}
+        @optionValuePath="value"
+        @optionLabelPath="name"
+        @includeBlank={{false}}
+        @update={{this.setPublishAction}}
+        @id="publish-action"
+        @name="publish-action" />
+    {{svg-jar "arrow-down-small"}}
+</span>

--- a/app/components/gh-distribution-action-select.js
+++ b/app/components/gh-distribution-action-select.js
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+
+export default class GhDistributionActionSelect extends Component {
+    @tracked
+    distributionValue;
+
+    constructor(...args) {
+        super(...args);
+
+        let distributionValue = this.args.post.emailOnly
+            ? 'send'
+            : (this.args.post.emailRecipientFilter !== 'none')
+                ? 'publish_send'
+                : 'publish';
+        this.distributionValue = this.availablePublishActions.findBy('value', distributionValue);
+    }
+
+    get availablePublishActions() {
+        return [{
+            value: 'publish_send',
+            name: 'publish & send'
+        }, {
+            value: 'publish',
+            name: 'publish'
+        }, {
+            value: 'send',
+            name: 'send'
+        }];
+    }
+
+    @action
+    setPublishAction(newAction) {
+        this.distributionValue = newAction;
+
+        if (newAction.value === 'publish_send') {
+            this.args.post.emailOnly = false;
+            this.args.post.emailRecipientFilter = null;
+        } else if (newAction.value === 'publish') {
+            this.args.post.emailOnly = false;
+            this.args.post.emailRecipientFilter = 'none';
+        } else if (newAction.value === 'send') {
+            this.args.post.emailOnly = true;
+            this.args.post.emailRecipientFilter = null;
+        }
+
+        this.args.post.save();
+    }
+}

--- a/app/components/gh-post-settings-menu.hbs
+++ b/app/components/gh-post-settings-menu.hbs
@@ -73,22 +73,6 @@
                 </div>
                 {{/unless}}
 
-                {{#if this.showEmailOnlyInput}}
-                    <div class="form-group for-checkbox">
-                        <label class="checkbox" for="emailOnly" {{action "toggleEmailOnly" bubbles="false"}}>
-                            <input
-                                type="checkbox"
-                                checked={{this.post.emailOnly}}
-                                class="gh-input post-settings-email-only"
-                                onclick={{action (mut this.post.emailOnly) value="target.checked"}}
-                                data-test-checkbox="emailOnly"
-                            >
-                            <span class="input-toggle-component"></span>
-                            <p>Set post to email only</p>
-                        </label>
-                    </div>
-                {{/if}}
-
                 {{#if this.showVisibilityInput}}
                     {{#if (feature "multipleProducts")}}
                         <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="visibility">

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -47,10 +47,6 @@ export default Component.extend({
     showVisibilityInput: or('session.user.isOwnerOnly', 'session.user.isAdminOnly', 'session.user.isEditor'),
     showEmailNewsletter: or('session.user.isOwnerOnly', 'session.user.isAdminOnly', 'session.user.isEditor'),
 
-    showEmailOnlyInput: computed('post.isPost', function () {
-        return this.feature.get('emailOnlyPosts') && this.get('post.isPost');
-    }),
-
     seoTitle: computed('metaTitleScratch', 'post.titleScratch', function () {
         return this.metaTitleScratch || this.post.titleScratch || '(Untitled)';
     }),
@@ -104,21 +100,6 @@ export default Component.extend({
 
         discardEnter() {
             return false;
-        },
-
-        toggleEmailOnly() {
-            this.toggleProperty('post.emailOnly');
-
-            // If this is a new post.  Don't save the post.  Defer the save
-            // to the user pressing the save button
-            if (this.get('post.isNew')) {
-                return;
-            }
-
-            this.savePostTask.perform().catch((error) => {
-                this.showError(error);
-                this.post.rollbackAttributes();
-            });
         },
 
         toggleFeatured() {

--- a/app/components/gh-publishmenu-draft.hbs
+++ b/app/components/gh-publishmenu-draft.hbs
@@ -1,5 +1,14 @@
 <div {{did-insert (fn this.setSaveType "publish")}} ...attributes>
-    <header class="gh-publishmenu-heading">Ready to {{this.nextActionName}} this {{@post.displayName}}?</header>
+    <header class="gh-publishmenu-heading">Ready to
+        {{#if this.showEmailOnlyInput}}
+            <GhDistributionActionSelect
+                @post={{@post}}
+            />
+        {{else}}
+            {{this.nextActionName}}
+        {{/if}}
+        this {{@post.displayName}}?
+    </header>
     <section class="gh-publishmenu-content">
         <div class="gh-publishmenu-section">
             <div class="gh-publishmenu-radio {{if (eq @saveType "publish") "active"}}" {{on "click" (fn this.setSaveType "publish")}}>
@@ -30,7 +39,7 @@
             </div>
         </div>
 
-        {{#if @canSendEmail}}
+        {{#if this.showEmailSection}}
             <div class="gh-publishmenu-section" {{did-insert (perform this.countTotalMembersTask)}}>
                 <div class="gh-publishmenu-email">
                     {{#if @isSendingEmailLimited}}

--- a/app/components/gh-publishmenu-draft.js
+++ b/app/components/gh-publishmenu-draft.js
@@ -28,6 +28,14 @@ export default class GhPublishMenuDraftComponent extends Component {
         return this.args.post.get('emailOnly') ? 'send' : 'publish';
     }
 
+    get showEmailSection() {
+        return this.args.canSendEmail && this.args.post.get('emailRecipientFilter') !== 'none';
+    }
+
+    get showEmailOnlyInput() {
+        return this.feature.get('emailOnlyPosts') && this.args.post.get('isPost');
+    }
+
     constructor() {
         super(...arguments);
         this.args.post.set('publishedAtBlogTZ', this.args.post.publishedAtUTC);

--- a/app/components/gh-publishmenu-draft.js
+++ b/app/components/gh-publishmenu-draft.js
@@ -25,15 +25,15 @@ export default class GhPublishMenuDraftComponent extends Component {
     }
 
     get nextActionName() {
-        return this.args.post.get('emailOnly') ? 'send' : 'publish';
+        return this.args.post.emailOnly ? 'send' : 'publish';
     }
 
     get showEmailSection() {
-        return this.args.canSendEmail && this.args.post.get('emailRecipientFilter') !== 'none';
+        return this.args.canSendEmail && this.args.post.emailRecipientFilter !== 'none';
     }
 
     get showEmailOnlyInput() {
-        return this.feature.get('emailOnlyPosts') && this.args.post.get('isPost');
+        return this.feature.emailOnlyPosts && this.args.post.isPost;
     }
 
     constructor() {

--- a/tests/integration/components/gh-distribution-action-select-test.js
+++ b/tests/integration/components/gh-distribution-action-select-test.js
@@ -1,0 +1,39 @@
+import hbs from 'htmlbars-inline-precompile';
+import mockPosts from '../../../mirage/config/posts';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find, findAll, render, settled} from '@ember/test-helpers';
+import {setupRenderingTest} from 'ember-mocha';
+import {startMirage} from 'ghost-admin/initializers/ember-cli-mirage';
+
+describe('Integration: Component: gh-distribution-action-select', function () {
+    setupRenderingTest();
+    let server;
+
+    beforeEach(function () {
+        server = startMirage();
+        let author = server.create('user');
+
+        mockPosts(server);
+
+        server.create('post', {authors: [author]});
+
+        this.set('store', this.owner.lookup('service:store'));
+    });
+
+    afterEach(function () {
+        server.shutdown();
+    });
+
+    it('renders', async function () {
+        this.set('post', this.store.findRecord('post', 1));
+        await settled();
+
+        await render(hbs`<GhDistributionActionSelect @post=post />`);
+
+        expect(this.element, 'top-level elements').to.exist;
+        expect(find('#publish-action'), 'publish action').to.exist;
+        expect(findAll('option'), 'number of options').to.have.length(3);
+        expect(find('select').value, 'selected option value').to.equal('publish_send');
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/947

The PR aims to implement following design to allow the end user selecting the "distribution" option:
![image](https://user-images.githubusercontent.com/675397/130624296-8d6d4eeb-d731-4c32-bfc5-77cae4f7622c.png)

@kevinansfield there are couple places I've got stuck with the changes after multiple different approach. Would love your expert help :)

Below are related to changes introduced in `Added publishing action dropdown to publish menu ` commit:
1. The basic test I've tried covering the new component with is failing due to "post" not being an ember model object :thinking: I've taken the pattern from [gh-psm-tags-input-test.js](https://github.com/TryGhost/Admin/blob/faabc6018b01d7839f4b7d98fa3e66442978ae4f/tests/integration/components/gh-psm-tags-input-test.js#L83) test and it doesn't seem to work? Is there a correct pattern to follow when mocking a post model in component unit tests?
2. The second problem is related to the one from pt. 1 I suspect. The component doesn't seem to assign the `distributionValue` correctly, which results on lost state when the publish menu is closed and reopened again.

Soz, these seem like noob level problems but have been stuck at them long enough, so decided to just ask :sweat_smile: :pray: 