### PR TITLE
Wired up custom theme settings display

### DIFF
--- a/app/components/modals/design/customize.hbs
+++ b/app/components/modals/design/customize.hbs
@@ -26,10 +26,12 @@
 
         <div class="gh-branding-settings">
             <section class="gh-branding-settings-options">
-                <div class="gh-btn-group gh-design-settings-tabs">
-                    <button type="button" class="gh-btn {{if (eq this.tab "general") "gh-btn-group-selected"}}" {{on "click" (fn this.changeTab "general")}}><span>General</span></button>
-                    <button type="button" class="gh-btn {{if (eq this.tab "theme") "gh-btn-group-selected"}}" {{on "click" (fn this.changeTab "theme")}}><span>Theme</span></button>
-                </div>
+                {{#if this.themeSettings}}
+                    <div class="gh-btn-group gh-design-settings-tabs">
+                        <button type="button" class="gh-btn {{if (eq this.tab "general") "gh-btn-group-selected"}}" {{on "click" (fn this.changeTab "general")}}><span>General</span></button>
+                        <button type="button" class="gh-btn {{if (eq this.tab "theme") "gh-btn-group-selected"}}" {{on "click" (fn this.changeTab "theme")}}><span>Theme</span></button>
+                    </div>
+                {{/if}}
 
                 {{#if (eq this.tab "general")}}
                     <Modals::Design::Customize::GeneralSettings
@@ -37,6 +39,8 @@
                     />
                 {{else if (eq this.tab "theme")}}
                     <Modals::Design::Customize::ThemeSettings
+                        @isLoading={{this.fetchThemeSettingsTask.isRunning}}
+                        @themeSettings={{this.themeSettings}}
                         @updatePreview={{perform this.updatePreviewTask}}
                     />
                 {{/if}}

--- a/app/components/modals/design/customize/theme-settings.hbs
+++ b/app/components/modals/design/customize/theme-settings.hbs
@@ -1,14 +1,22 @@
 <div class="gh-stack">
-    <div class="gh-stack-item gh-setting-first">
-        <div class="flex-grow-1">
-            <div class="gh-setting-title gh-theme-setting-title">Title font</div>
+    {{#each @themeSettings as |setting index|}}
+        {{#if (eq setting.type "select")}}
+            <div class="gh-stack-item gh-setting-first">
+                <div class="flex-grow-1">
+                    <div class="gh-setting-title gh-theme-setting-title">
+                        {{humanize setting.key}}
+                    </div>
 
-                <select class="ember-select">
-                    <option value="Inter">Inter</option>
-                    <option value="Open Sans">Open Sans</option>
-                    <option value="Georgia">Georgia</option>
-                    <option value="Source Serif Pro">Source Serif Pro</option>
-                </select>
-        </div>
-    </div>
+                    <select class="ember-select">
+                        {{#each setting.options as |settingOption|}}
+                            <option value={{option}} selected={{eq settingOption setting.value}}>
+                                {{settingOption}}
+                                {{#if (eq settingOption setting.default)}}(default){{/if}}
+                            </option>
+                        {{/each}}
+                    </select>
+                </div>
+            </div>
+        {{/if}}
+    {{/each}}
 </div>

--- a/app/models/custom-theme-setting.js
+++ b/app/models/custom-theme-setting.js
@@ -1,0 +1,9 @@
+import Model, {attr} from '@ember-data/model';
+
+export default Model.extend({
+    key: attr('string'),
+    type: attr('string'),
+    options: attr(),
+    default: attr('string'),
+    value: attr('string')
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1070
reqs https://github.com/TryGhost/Ghost/pull/13362

- added custom theme setting model
- added fetch of custom theme settings when customize modal is opened
- used loaded theme settings to populate settings list in theme settings tab
- hid the general/theme toggle when no theme settings are present
