### PR TITLE
Added save of custom settings from customize design screen

### DIFF
--- a/app/adapters/custom-theme-setting-list.js
+++ b/app/adapters/custom-theme-setting-list.js
@@ -1,0 +1,15 @@
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+
+export default class CustomThemeSettingListAdapter extends ApplicationAdapter {
+    // we use `custom-theme-setting-list` model as a workaround for saving all
+    // custom theme setting records in one request so it uses the base model url
+    pathForType() {
+        return 'custom_theme_settings';
+    }
+
+    // there's no custom theme setting creation
+    // newListModel.save() acts as an overall update request so force a PUT
+    createRecord(store, type, snapshot) {
+        return this.saveRecord(store, type, snapshot, {method: 'PUT'}, 'createRecord');
+    }
+}

--- a/app/components/custom-theme-settings/select.hbs
+++ b/app/components/custom-theme-settings/select.hbs
@@ -1,0 +1,16 @@
+<div class="gh-stack-item {{if (eq @index 0) "gh-setting-first"}}">
+    <div class="flex-grow-1">
+        <label class="gh-setting-title gh-theme-setting-title" for={{this.selectId}}>
+            {{humanize @setting.key}}
+        </label>
+
+        <select class="ember-select" name={{this.selectName}} id={{this.selectId}} {{on "change" this.setSelection}}>
+            {{#each @setting.options as |settingOption|}}
+                <option value={{settingOption}} selected={{eq settingOption @setting.value}}>
+                    {{settingOption}}
+                    {{#if (eq settingOption setting.default)}}(default){{/if}}
+                </option>
+            {{/each}}
+        </select>
+    </div>
+</div>

--- a/app/components/custom-theme-settings/select.js
+++ b/app/components/custom-theme-settings/select.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {camelize} from '@ember/string';
+import {guidFor} from '@ember/object/internals';
+
+export default class CustomThemeSettingsSelectComponent extends Component {
+    selectId = `select-${guidFor(this)}`;
+    selectName = camelize(this.args.setting.key);
+
+    @action
+    setSelection(changeEvent) {
+        const value = changeEvent.target.value;
+        this.args.setting.set('value', value);
+    }
+}

--- a/app/components/modals/design/customize.js
+++ b/app/components/modals/design/customize.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import config from 'ghost-admin/config/environment';
 import {action} from '@ember/object';
-import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 import {tracked} from '@glimmer/tracking';
@@ -9,8 +8,8 @@ import {tracked} from '@glimmer/tracking';
 export default class ModalsDesignCustomizeComponent extends Component {
     @service ajax;
     @service config;
+    @service customThemeSettings;
     @service settings;
-    @service store;
 
     @tracked tab = 'general';
 
@@ -22,7 +21,7 @@ export default class ModalsDesignCustomizeComponent extends Component {
     }
 
     get themeSettings() {
-        return this.store.peekAll('custom-theme-setting');
+        return this.customThemeSettings.settings;
     }
 
     @action
@@ -47,10 +46,7 @@ export default class ModalsDesignCustomizeComponent extends Component {
 
     @task
     *fetchThemeSettingsTask() {
-        // unload stored settings and re-load from API so they always match active theme
-        // run is required here, see https://github.com/emberjs/data/issues/5447#issuecomment-845672812
-        run(() => this.store.unloadAll('custom-theme-setting'));
-        yield this.store.findAll('custom-theme-setting');
+        yield this.customThemeSettings.load();
     }
 
     @task

--- a/app/components/modals/design/customize/theme-settings.hbs
+++ b/app/components/modals/design/customize/theme-settings.hbs
@@ -1,22 +1,9 @@
 <div class="gh-stack">
-    {{#each @themeSettings as |setting index|}}
-        {{#if (eq setting.type "select")}}
-            <div class="gh-stack-item gh-setting-first">
-                <div class="flex-grow-1">
-                    <div class="gh-setting-title gh-theme-setting-title">
-                        {{humanize setting.key}}
-                    </div>
-
-                    <select class="ember-select">
-                        {{#each setting.options as |settingOption|}}
-                            <option value={{option}} selected={{eq settingOption setting.value}}>
-                                {{settingOption}}
-                                {{#if (eq settingOption setting.default)}}(default){{/if}}
-                            </option>
-                        {{/each}}
-                    </select>
-                </div>
-            </div>
-        {{/if}}
-    {{/each}}
+    <form>
+        {{#each @themeSettings as |setting index|}}
+            {{#if (eq setting.type "select")}}
+                <CustomThemeSettings::Select @setting={{setting}} @index={{index}} />
+            {{/if}}
+        {{/each}}
+    </form>
 </div>

--- a/app/controllers/settings/design/customize.js
+++ b/app/controllers/settings/design/customize.js
@@ -3,8 +3,10 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 
 export default class SettingsDesignCustomizeController extends Controller {
-    @service settings;
+    @service customThemeSettings;
+    @service notifications;
     @service router;
+    @service settings;
 
     @task
     *saveTask() {
@@ -12,8 +14,15 @@ export default class SettingsDesignCustomizeController extends Controller {
             if (this.settings.get('errors').length !== 0) {
                 return;
             }
-            yield this.settings.save();
+
+            yield Promise.all(
+                this.settings.save(),
+                this.customThemeSettings.save()
+            );
+
             this.router.transitionTo('settings.design');
+
+            // ensure task button switches to success state
             return true;
         } catch (error) {
             if (error) {

--- a/app/models/custom-theme-setting-list.js
+++ b/app/models/custom-theme-setting-list.js
@@ -1,0 +1,5 @@
+import Model, {hasMany} from '@ember-data/model';
+
+export default Model.extend({
+    customThemeSettings: hasMany('custom-theme-setting')
+});

--- a/app/routes/settings/design/customize.js
+++ b/app/routes/settings/design/customize.js
@@ -4,6 +4,7 @@ import {bind} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
 export default class SettingsDesignCustomizeRoute extends AuthenticatedRoute {
+    @service customThemeSettings;
     @service feature;
     @service modals;
     @service settings;
@@ -35,7 +36,7 @@ export default class SettingsDesignCustomizeRoute extends AuthenticatedRoute {
 
     @action
     async willTransition(transition) {
-        if (this.settings.get('hasDirtyAttributes')) {
+        if (this.settings.get('hasDirtyAttributes') || this.customThemeSettings.isDirty) {
             transition.abort();
 
             const shouldLeave = await this.confirmUnsavedChanges();
@@ -73,7 +74,7 @@ export default class SettingsDesignCustomizeRoute extends AuthenticatedRoute {
     }
 
     confirmUnsavedChanges() {
-        if (!this.settings.get('hasDirtyAttributes')) {
+        if (!this.settings.get('hasDirtyAttributes') && !this.customThemeSettings.isDirty) {
             return Promise.resolve(true);
         }
 
@@ -83,6 +84,7 @@ export default class SettingsDesignCustomizeRoute extends AuthenticatedRoute {
             }).then((discardChanges) => {
                 if (discardChanges === true) {
                     this.settings.rollbackAttributes();
+                    this.customThemeSettings.rollback();
                 }
                 return discardChanges;
             }).finally(() => {

--- a/app/serializers/custom-theme-setting-list.js
+++ b/app/serializers/custom-theme-setting-list.js
@@ -1,0 +1,23 @@
+import ApplicationSerializer from './application';
+import {EmbeddedRecordsMixin} from '@ember-data/serializer/rest';
+
+export default class CustomThemeSettingList extends ApplicationSerializer.extend(EmbeddedRecordsMixin) {
+    attrs = {
+        customThemeSettings: {embedded: 'always'}
+    }
+
+    serializeIntoHash(hash, type, record, options) {
+        // replace the whole request hash with the embedded custom_theme_settings array
+        const settings = this.serialize(record, options);
+        Object.assign(hash, settings);
+    }
+
+    normalizeSingleResponse(store, primaryModelClass, _payload, id, requestType) {
+        // response will come back as a custom theme settings array, not a "customThemeSettingList" array/object
+        // make it look like the list model so Ember Data does it's thing and doesn't complain
+        const payload = {
+            customThemeSettingLists: [Object.assign({id: 0}, _payload)]
+        };
+        return super.normalizeSingleResponse(store, primaryModelClass, payload, id, requestType);
+    }
+}

--- a/app/services/custom-theme-settings.js
+++ b/app/services/custom-theme-settings.js
@@ -9,6 +9,11 @@ export default class CustomThemeSettingsServices extends Service {
 
     @tracked settings = [];
 
+    get isDirty() {
+        const dirtySetting = this.settings.find(setting => setting.hasDirtyAttributes);
+        return !!dirtySetting;
+    }
+
     load() {
         return this.loadTask.perform();
     }

--- a/app/services/custom-theme-settings.js
+++ b/app/services/custom-theme-settings.js
@@ -1,0 +1,49 @@
+import Service from '@ember/service';
+import {run} from '@ember/runloop';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency-decorators';
+import {tracked} from '@glimmer/tracking';
+
+export default class CustomThemeSettingsServices extends Service {
+    @service store;
+
+    @tracked settings = [];
+
+    load() {
+        return this.loadTask.perform();
+    }
+
+    @task
+    *loadTask() {
+        // unload stored settings and re-load from API so they always match active theme
+        // run is required here, see https://github.com/emberjs/data/issues/5447#issuecomment-845672812
+        run(() => this.store.unloadAll('custom-theme-setting'));
+
+        const settings = yield this.store.findAll('custom-theme-setting');
+        this.settings = settings;
+
+        return this.settings;
+    }
+
+    save() {
+        return this.saveTask.perform();
+    }
+
+    @task
+    *saveTask() {
+        // save all records in a single request to `/custom_theme_settings`
+        const listRecord = this.store.createRecord('custom-theme-setting-list', {customThemeSettings: this.settings});
+        yield listRecord.save();
+
+        // don't keep references to individual settings around
+        this.store.unloadRecord(listRecord);
+
+        return this.settings;
+    }
+
+    rollback() {
+        run(() => this.store.unloadAll('custom-theme-setting'));
+
+        this.settings = [];
+    }
+}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1070

- adds a `customThemeSettings` service that handles overall setting loading and saving to avoid components having to know any of the intricacies of the model setup
- adds `custom-theme-setting-list` model so that we can save multiple setting records as embedded relations
  - custom adapter ensures requests go to the `/custom_theme_settings` base route as a `PUT` request
  - custom serializer drops the default `models: []` wrapper in the request data so the format matches the `PUT /settings` endpoint