### PR TITLE
Fixed incorrect status showing up when sent post is updated

### DIFF
--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -83,7 +83,7 @@ const messageMap = {
                 sent: 'Sent'
             },
             sent: {
-                sent: 'Sent'
+                sent: 'Updated'
             }
         }
     }


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/CORE-79/editing-saving-a-post-that-has-already-been-sent-flashes-sent-as-the

- The mapping was wong in a previous version - when the status changes from 'sent' to 'sent' the notification box should show 'Updated' instead of 'sent', doh!
