### PR TITLE
:bug: Currency dropdown had incorrect background shade in dark mode

### DIFF
--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -1941,13 +1941,11 @@ p.theme-validation-details {
     padding: 0;
     width: 60px;
     height: 16px;
-    background: transparent;
     border: none;
     margin-left: -4px;
 }
 
 .gh-settings-members-pricelabelcont .gh-select select {
-    background: transparent;
     font-size: 1.4rem;
     font-weight: 500;
     border: none;


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/13598
- dark mode was showing incorrect colours for dropdown

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
