### PR TITLE
🐛 Fixed member settings preview not working in private mode

### DIFF
--- a/app/components/gh-brand-settings-form.js
+++ b/app/components/gh-brand-settings-form.js
@@ -17,6 +17,7 @@ export default class GhBrandSettingsFormComponent extends Component {
     @service config;
     @service ghostPaths;
     @service settings;
+    @service frontend;
 
     iconExtensions = ICON_EXTENSIONS;
     iconMimeTypes = ICON_MIME_TYPES;
@@ -141,18 +142,16 @@ export default class GhBrandSettingsFormComponent extends Component {
             return;
         }
 
-        // grab the preview html
-        const ajaxOptions = {
-            contentType: 'text/html;charset=utf-8',
-            dataType: 'text',
+        const frontendUrl = '/';
+        const previewResponse = yield this.frontend.fetch(frontendUrl, {
+            method: 'POST',
             headers: {
-                'x-ghost-preview': this.previewData
+                'Content-Type': 'text/html;charset=utf-8',
+                'x-ghost-preview': this.previewData,
+                Accept: 'text/plain'
             }
-        };
-
-        // TODO: config.blogUrl always removes trailing slash - switch to always have trailing slash
-        const frontendUrl = `${this.config.get('blogUrl')}/`;
-        const previewContents = yield this.ajax.post(frontendUrl, ajaxOptions);
+        });
+        const previewContents = yield previewResponse.text();
 
         // inject extra CSS to disable navigation and prevent clicks
         const injectedCss = `html { pointer-events: none; }`;

--- a/app/components/modal-portal-settings.js
+++ b/app/components/modal-portal-settings.js
@@ -272,7 +272,6 @@ export default ModalComponent.extend({
         }
 
         this.siteUrl = this.config.get('blogUrl');
-
         this.set('isPreloading', false);
     }),
 

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -24,6 +24,7 @@ export default Controller.extend({
     notifications: service(),
     session: service(),
     settings: service(),
+    frontend: service(),
     ui: service(),
 
     availableTimezones: null,
@@ -269,9 +270,12 @@ export default Controller.extend({
         }
 
         try {
+            let changedAttrs = this.settings.changedAttributes();
             let settings = yield this.settings.save();
             config.set('blogTitle', settings.get('title'));
-
+            if (changedAttrs.password) {
+                this.frontend.loginIfNeeded();
+            }
             // this forces the document title to recompute after a blog title change
             this.ui.updateDocumentTitle();
 

--- a/app/routes/site.js
+++ b/app/routes/site.js
@@ -1,5 +1,4 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
-import fetch from 'fetch';
 import {inject as service} from '@ember/service';
 
 export default AuthenticatedRoute.extend({
@@ -11,25 +10,6 @@ export default AuthenticatedRoute.extend({
 
     model() {
         return (new Date()).valueOf();
-    },
-
-    afterModel() {
-        if (this.settings.get('isPrivate') && !this._hasLoggedIn) {
-            let privateLoginUrl = `${this.config.get('blogUrl')}/private/?r=%2F`;
-
-            return fetch(privateLoginUrl, {
-                method: 'POST',
-                mode: 'cors',
-                redirect: 'manual',
-                credentials: 'include',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                },
-                body: `password=${this.settings.get('password')}`
-            }).then(() => {
-                this._hasLoggedIn = true;
-            });
-        }
     },
 
     buildRouteInfoMetadata() {

--- a/app/services/frontend.js
+++ b/app/services/frontend.js
@@ -1,0 +1,57 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+import validator from 'validator';
+import {inject as service} from '@ember/service';
+
+export default class FrontendService extends Service {
+    @service settings;
+    @service config;
+    @service ajax;
+
+    _hasLoggedIn = false;
+    _lastPassword = null;
+
+    get hasPasswordChanged() {
+        return this._lastPassword !== this.settings.get('password');
+    }
+
+    getUrl(path) {
+        const siteUrl = new URL(this.config.get('blogUrl'));
+        const subdir = siteUrl.pathname.endsWith('/') ? siteUrl.pathname : `${siteUrl.pathname}/`;
+        const fullPath = `${subdir}${path.replace(/^\//, '')}`;
+
+        return `${siteUrl.origin}${fullPath}`;
+    }
+
+    async loginIfNeeded() {
+        if (this.settings.get('isPrivate') && (this.hasPasswordChanged || !this._hasLoggedIn)) {
+            const privateLoginUrl = this.getUrl('/private/?r=%2F');
+            this._lastPassword = this.settings.get('password');
+            return fetch(privateLoginUrl, {
+                method: 'POST',
+                mode: 'cors',
+                redirect: 'manual',
+                credentials: 'include',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                body: `password=${this._lastPassword}`
+            }).then(() => {
+                this._hasLoggedIn = true;
+            });
+        }
+    }
+
+    async fetch(urlOrPath, options) {
+        await this.loginIfNeeded();
+        let frontendUrl = urlOrPath;
+        if (!validator.isURL(urlOrPath)) {
+            frontendUrl = this.getUrl(urlOrPath);
+        }
+        return fetch(frontendUrl, {
+            mode: 'cors',
+            credentials: 'include',
+            ...options
+        });
+    }
+}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -12,6 +12,7 @@ export default class SessionService extends ESASessionService {
     @service feature;
     @service notifications;
     @service router;
+    @service frontend;
     @service settings;
     @service ui;
     @service upgradeStatus;
@@ -37,7 +38,7 @@ export default class SessionService extends ESASessionService {
             this.feature.fetch(),
             this.settings.fetch()
         ]);
-
+        await this.frontend.loginIfNeeded();
         // update Sentry with the full Ghost version which we only get after authentication
         if (this.config.get('sentry_dsn')) {
             configureScope((scope) => {

--- a/app/services/theme-management.js
+++ b/app/services/theme-management.js
@@ -15,6 +15,7 @@ export default class ThemeManagementService extends Service {
     @service modals;
     @service settings;
     @service store;
+    @service frontend;
 
     @tracked isUploading;
     @tracked previewType = 'homepage';
@@ -152,17 +153,7 @@ export default class ThemeManagementService extends Service {
             return;
         }
 
-        // grab the preview html
-        const ajaxOptions = {
-            contentType: 'text/html;charset=utf-8',
-            dataType: 'text',
-            headers: {
-                'x-ghost-preview': this.previewData
-            }
-        };
-
-        // TODO: config.blogUrl always removes trailing slash - switch to always have trailing slash
-        let frontendUrl = `${this.config.get('blogUrl')}/`;
+        let frontendUrl = '/';
 
         if (this.previewType === 'post') {
             // in case we haven't loaded any posts so far
@@ -173,7 +164,15 @@ export default class ThemeManagementService extends Service {
             frontendUrl = this.latestPublishedPost.url;
         }
 
-        const previewContents = yield this.ajax.post(frontendUrl, ajaxOptions);
+        const previewResponse = yield this.frontend.fetch(frontendUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'text/html;charset=utf-8',
+                'x-ghost-preview': this.previewData,
+                Accept: 'text/plain'
+            }
+        });
+        const previewContents = yield previewResponse.text();
 
         // inject extra CSS to disable navigation and prevent clicks
         const injectedCss = `html { pointer-events: none; }`;


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1161

- when a site is in private mode, the portal previews on membership, customize portal and offer pages were unable to load. Unlike site preview, member settings pages were not authenticating private site behind the scenes to allow site to load in admin
- this change adds a new service that authenticates private site from admin as soon as user session is loaded, so previews on member settings will always find the authenticated session for private sites and load correctly. it also updates the session on password change from admin
- also updates the usage of fetching preview data via a single method in frontend service