### PR TITLE
Moved launch complete flag to new setting

### DIFF
--- a/app/components/gh-launch-wizard/finalise.js
+++ b/app/components/gh-launch-wizard/finalise.js
@@ -50,9 +50,9 @@ export default class GhLaunchWizardFinaliseComponent extends Component {
         const data = this.args.getData();
         if (data?.product) {
             yield this.saveProduct();
+            this.settings.set('editorIsLaunchComplete', true);
             yield this.settings.save();
         }
-        yield this.feature.set('launchComplete', true);
         this.router.transitionTo('dashboard');
         this.notifications.showNotification(
             'Launch complete!',

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -235,6 +235,7 @@ export default class DashboardController extends Controller {
 
     @action
     dismissLaunchBanner() {
-        this.feature.set('launchComplete', true);
+        this.settings.set('editorIsLaunchComplete', true);
+        this.settings.save();
     }
 }

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -94,6 +94,7 @@ export default Model.extend(ValidationEngine, {
     /**
      * Editor settings
      */
+    editorIsLaunchComplete: attr('boolean'),
     editorDefaultEmailRecipients: attr('string'),
     editorDefaultEmailRecipientsFilter: attr('members-segment-string'),
     emailVerificationRequired: attr('boolean'),

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -7,7 +7,7 @@
 
     <div class="view-container gh-dashboard">
 
-        {{#if (and this.session.user.isOwnerOnly (not this.feature.launchComplete))}}
+        {{#if (and this.session.user.isOwnerOnly (not this.settings.editorIsLaunchComplete))}}
             <section class="gh-dashboard-area lw-banner">
                 <div class="gh-lw-banner" style="background-image:url(assets/img/launch-wizard-bg.png);">
                     <h1>Select your publication style</h1>
@@ -287,7 +287,7 @@
                     </div>
                 {{/if}}
 
-                {{#unless (and this.session.user.isOwnerOnly (not this.feature.launchComplete))}}
+                {{#unless (and this.session.user.isOwnerOnly (not this.feature.editorIsLaunchComplete))}}
                     <div class="gh-dashboard-box grey activity-feed">
                         <h4 class="gh-dashboard-header">Activity feed</h4>
                         <div class="content">


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/807
refs https://github.com/TryGhost/Ghost/pull/13703

The launch wizard completed flag was previously stored at per user level in accessibility column of user table, so an administrator still got the option to complete the launch wizard even if the owner had completed it previously, which is not expected pattern. This change moves the launch complete flag to be stored in new global setting for a site.
