### PR TITLE
Allowed tab switch for heading to content input in toggle card

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-basic-html-input.js
+++ b/lib/koenig-editor/addon/components/koenig-basic-html-input.js
@@ -57,6 +57,7 @@ export default Component.extend({
     didCreateEditor() {},
     onChange() {},
     onNewline() {},
+    onTab() {},
     onFocus() {},
     onBlur() {},
 
@@ -230,7 +231,13 @@ export default Component.extend({
         let editorElement = this.element.querySelector('[data-kg="editor"]');
 
         this._pasteHandler = run.bind(this, this.handlePaste);
+        this._tabHandler = run.bind(this, this.onTab);
         editorElement.addEventListener('paste', this._pasteHandler);
+        editorElement.addEventListener('keydown', (e) => {
+            if (e.key === 'Tab') {
+                this._tabHandler(e);
+            }
+        });
 
         this.element.dataset[DRAG_DISABLED_DATA_ATTR] = 'true';
     },

--- a/lib/koenig-editor/addon/components/koenig-card-toggle.hbs
+++ b/lib/koenig-editor/addon/components/koenig-card-toggle.hbs
@@ -35,6 +35,7 @@
                 @onFocus={{action (mut this.isFocused) true}}
                 @onBlur={{action (mut this.isFocused) false}}
                 {{!-- @onNewline={{action "handleEnter"}} --}}
+                @onTab={{action "handleTab"}}
                 @didCreateEditor={{action "registerEditor"}}
             />
             <KoenigBasicHtmlTextarea

--- a/lib/koenig-editor/addon/components/koenig-card-toggle.js
+++ b/lib/koenig-editor/addon/components/koenig-card-toggle.js
@@ -87,6 +87,17 @@ export default class KoenigCardToggleComponent extends Component {
     }
 
     @action
+    handleTab(event) {
+        event?.preventDefault();
+        event?.stopImmediatePropagation();
+        let contentInput = this.element.querySelector('.kg-accordion-card-content .koenig-basic-html-textarea__editor');
+
+        if (contentInput) {
+            contentInput.focus();
+        }
+    }
+
+    @action
     registerEditor(textReplacementEditor) {
         let commands = {
             'META+ENTER': run.bind(this, this._enter, 'meta'),


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1209

- allows switching to content input from heading by pressing tab
