### PR TITLE
Allowed popups from email preview to escape sandbox

### DIFF
--- a/app/components/modals/post-preview/email.hbs
+++ b/app/components/modals/post-preview/email.hbs
@@ -6,7 +6,7 @@
             </p>
             <p><span class="dark">To:</span> Jamie Larson &lt;jamie@example.com&gt;</p>
         </div>
-        <iframe class="gh-pe-iframe" {{did-insert this.renderEmailPreview}} sandbox="allow-same-origin allow-popups"></iframe>
+        <iframe class="gh-pe-iframe" {{did-insert this.renderEmailPreview}} sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"></iframe>
     </div>
 </div>
 <div class="gh-post-preview-email-footer">


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1001

Our email newsletter preview is rendered inside of an iframe with
javascript disabled. When opening links from the preview, the new
window/tab inherits this property - which breaks links to twitter.
