### PR TITLE
Updating revenue number in membership settings

### DIFF
--- a/app/templates/settings/membership.hbs
+++ b/app/templates/settings/membership.hbs
@@ -21,7 +21,7 @@
 
         <div class="gh-main-layout content-preview">
             <div class="gh-setting-members-basicsform">
-                <p class="intro">Fund your work with subscription revenue. Connect your Stripe account and offer premium content to your audience. Our creators are already making over $5 million per year, while <strong>Ghost takes 0% payment fees</strong>.</p>
+                <p class="intro">Fund your work with subscription revenue. Connect your Stripe account and offer premium content to your audience. Our creators are already making over $12 million per year, while <strong>Ghost takes 0% payment fees</strong>.</p>
                 <hr>
                 <div>
                     <section class="gh-expandable gh-setting-members-portalcta">


### PR DESCRIPTION
Creators on Ghost have surpassed $12 million in revenue per year. We're updating the membership settings page to reflect that. 