### PR TITLE
Fix dashboard chart width on wide screens

### DIFF
--- a/app/styles/layouts/dashboard.css
+++ b/app/styles/layouts/dashboard.css
@@ -413,6 +413,7 @@ a.gh-dashboard-container {
     flex-direction: column;
     align-items: flex-end;
     justify-content: flex-end;
+    width: 100%;
 }
 
 .gh-dashboard-chart.nodata {
@@ -436,14 +437,14 @@ a.gh-dashboard-container {
     display: flex;
     justify-content: stretch;
     height: 228px;
-    width: 35.5vw;
+    width: 100%;
     padding-top: 12px;
     margin-right: -10px;
 }
 
 .gh-dashboard-chart-box.small {
     position: relative;
-    width: 14vw;
+    /* width: 14vw; */
     min-width: 165px;
     height: 110px;
     padding-top: 0;

--- a/app/styles/layouts/dashboard.css
+++ b/app/styles/layouts/dashboard.css
@@ -444,7 +444,6 @@ a.gh-dashboard-container {
 
 .gh-dashboard-chart-box.small {
     position: relative;
-    /* width: 14vw; */
     min-width: 165px;
     height: 110px;
     padding-top: 0;


### PR DESCRIPTION
Currently, `.gh-dashboard-chart-box` uses `vw` unit which is dependent from the viewport width. This causes overflow issue when the screen width is very wide. This PR removes the `vw` based width, and makes it dependent from the container width, so that it fills the remaining space correctly.