### PR TITLE
Fix incorrect color on hover for publish and send buttons

### DIFF
--- a/app/components/gh-publishmenu.hbs
+++ b/app/components/gh-publishmenu.hbs
@@ -58,7 +58,7 @@
                 @taskArgs={{hash dropdown=dd}}
                 @successText={{this.successText}}
                 @runningText={{this.runningText}}
-                @class="gh-btn gh-btn-black gh-publishmenu-button gh-btn-icon"
+                @class="gh-btn gh-btn-green gh-publishmenu-button gh-btn-icon"
                 data-test-publishmenu-save="true"
             />
         </footer>

--- a/app/components/gh-publishmenu.hbs
+++ b/app/components/gh-publishmenu.hbs
@@ -58,7 +58,7 @@
                 @taskArgs={{hash dropdown=dd}}
                 @successText={{this.successText}}
                 @runningText={{this.runningText}}
-                @class="gh-btn gh-btn-green gh-publishmenu-button gh-btn-icon"
+                @class="gh-btn gh-btn-black gh-publishmenu-button gh-btn-icon"
                 data-test-publishmenu-save="true"
             />
         </footer>

--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -814,16 +814,6 @@ input:focus,
     background: var(--dark-main-bg-color) !important;
 }
 
-.gh-publishmenu-button {
-    color: var(--black);
-    background: var(--green-d1);
-}
-
-.gh-publishmenu-button:hover {
-    color: #fff;
-    background: var(--green) !important;
-}
-
 .gh-editor-feature-image-add-button {
     color: var(--midgrey);
 }


### PR DESCRIPTION
Ref Issue: [#13700](https://github.com/TryGhost/Ghost/issues/13700)

I've looked into this issue and its because of conflicting CSS styling rules on hover for the two classes associated with the button `gh-btn-black` and `gh-publishmenu-button`:

```
.gh-btn-black:not(.gh-btn-green):not(.gh-btn-blue):not(.gh-btn-red):hover,
.gh-btn-primary:not(.gh-btn-green):not(.gh-btn-blue):not(.gh-btn-red):hover {
    background: var(--black) !important;
}

.gh-publishmenu-button:hover {
    color: #fff;
    background: var(--green) !important; --> This is ignored
}
```

Removed conflicting gh-publishmenu-button CSS styling rules

![image](https://user-images.githubusercontent.com/2130096/152157620-cf0c6ced-7c32-41cb-99b8-4c8ff00d3b7a.png)

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
