### PR TITLE
Fixed display of warnings after content import

### DIFF
--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -1327,6 +1327,7 @@
 .gh-expandable {
     background: var(--main-color-content-greybg);
     border-radius: 3px;
+    overflow-x: hidden;
 }
 
 .gh-expandable-block {

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -1183,6 +1183,7 @@ body:not([data-user-is-dragging]) .gh-newsletter-card-draggable:hover .grab-news
     letter-spacing: 0.2px;
     background: #fff;
     border-radius: 5px;
+    margin-top: 18px;
     margin-bottom: 25px;
 }
 


### PR DESCRIPTION
No issue

- Fixes the horizontal overflow caused my longer warning/error messages. This means the `<pre>` tag is sized to fit the container and can now be scrolled and read in its entirety.
- Adds some top margin so these errors are not so bunched up to the text & input.

Before:

<img width="938" alt="screenshot-bhTDyBhk" src="https://user-images.githubusercontent.com/390392/148694585-b8b3a2c9-715c-4077-9ca9-26f1a542ee44.png">

After:

<img width="932" alt="screenshot-4qRHNfDT" src="https://user-images.githubusercontent.com/390392/148694594-2ef840ab-19bb-4a1b-97f0-80d0bb46dd88.png">

