### PR TITLE
Add optional secret to webhook form

### DIFF
--- a/app/components/modal-webhook-form.hbs
+++ b/app/components/modal-webhook-form.hbs
@@ -63,25 +63,23 @@
             <GhErrorMessage @errors={{this.webhook.errors}} @property="targetUrl" data-test-error="webhook-targetUrl" />
         </GhFormGroup>
     </fieldset>
-    {{#if (enable-developer-experiments)}}
-        <fieldset>
-            <GhFormGroup @errors={{this.webhook.errors}} @hasValidated={{this.webhook.hasValidated}} @property="secret">
-                <label for="webhook-secret" class="fw6">Secret</label>
-                <GhTextInput
-                    @value={{readonly this.webhook.secret}}
-                    @oninput={{action (mut this.webhook.secret) value="target.value"}}
-                    @focus-out={{action "validate" "secret" target=this.webhook}}
-                    @id="webhook-secret"
-                    @name="secret"
-                    @class="gh-input mt1"
-                    @shouldFocus={{true}}
-                    @autocapitalize="off"
-                    @autocorrect="off"
-                    data-test-input="webhook-secret" />
-                <GhErrorMessage @errors={{this.webhook.errors}} @property="secret" data-test-error="webhook-secret" />
-            </GhFormGroup>
-        </fieldset>
-    {{/if}}
+    <fieldset>
+        <GhFormGroup @errors={{this.webhook.errors}} @hasValidated={{this.webhook.hasValidated}} @property="secret">
+            <label for="webhook-secret" class="fw6">Secret</label>
+            <GhTextInput
+                @value={{readonly this.webhook.secret}}
+                @input={{action (mut this.webhook.secret) value="target.value"}}
+                @focus-out={{action "validate" "secret" target=this.webhook}}
+                @id="webhook-secret"
+                @name="secret"
+                @class="gh-input mt1"
+                @shouldFocus={{true}}
+                @autocapitalize="off"
+                @autocorrect="off"
+                data-test-input="webhook-secret" />
+            <GhErrorMessage @errors={{this.webhook.errors}} @property="secret" data-test-error="webhook-secret" />
+        </GhFormGroup>
+    </fieldset>
     {{#if this.error}}
         <p class="red">{{this.error}}</p>
     {{/if}}

--- a/app/validators/webhook.js
+++ b/app/validators/webhook.js
@@ -3,7 +3,7 @@ import validator from 'validator';
 import {isBlank} from '@ember/utils';
 
 export default BaseValidator.create({
-    properties: ['name', 'event', 'targetUrl'],
+    properties: ['name', 'event', 'targetUrl', 'secret'],
 
     name(model) {
         if (isBlank(model.name)) {
@@ -37,6 +37,14 @@ export default BaseValidator.create({
         model.hasValidated.pushObject('targetUrl');
 
         if (model.errors.has('targetUrl')) {
+            this.invalidate();
+        }
+    },
+
+    secret(model) {
+        if (!validator.isLength(model.secret, 0, 191)) {
+            model.errors.add('secret', 'Secret is too long, max 191 chars');
+            model.hasValidated.pushObject('secret');
             this.invalidate();
         }
     }


### PR DESCRIPTION
As per Pullrequest https://github.com/TryGhost/Ghost/pull/13980
there needs to be a possibility to add the secret to a webhook.

This PR adds another text input field to the webhook form.
