### PR TITLE
Refactored route objects to use native class syntax

### DIFF
--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -247,6 +247,16 @@ export default Controller.extend({
             this.toggleProperty('showEmailPreviewModal');
         },
 
+        openPostPreview(keyboardEvent) {
+            keyboardEvent?.preventDefault();
+
+            if (this.post.isDraft) {
+                this.send('openPostPreviewModal');
+            } else {
+                window.open(this.post.previewUrl, '_blank', 'noopener');
+            }
+        },
+
         openPostPreviewModal() {
             this.modals.open('modals/post-preview', {
                 post: this.post,

--- a/app/controllers/tags.js
+++ b/app/controllers/tags.js
@@ -1,8 +1,10 @@
 import Controller from '@ember/controller';
 import {alias, sort} from '@ember/object/computed';
 import {computed} from '@ember/object';
+import {inject as service} from '@ember/service';
 
 export default Controller.extend({
+    router: service(),
 
     queryParams: ['type'],
     type: 'public',
@@ -24,6 +26,10 @@ export default Controller.extend({
     actions: {
         changeType(type) {
             this.set('type', type);
+        },
+
+        newTag() {
+            this.router.transitionTo('tag.new');
         }
     }
 });

--- a/app/routes/authenticated.js
+++ b/app/routes/authenticated.js
@@ -1,10 +1,10 @@
 import Route from '@ember/routing/route';
 import {inject as service} from '@ember/service';
 
-export default Route.extend({
-    session: service(),
+export default class AuthenticatedRoute extends Route {
+    @service session;
 
     beforeModel(transition) {
         this.session.requireAuthentication(transition, 'signin');
     }
-});
+}

--- a/app/routes/designsandbox.js
+++ b/app/routes/designsandbox.js
@@ -1,13 +1,13 @@
 import Route from '@ember/routing/route';
 import {inject as service} from '@ember/service';
 
-export default Route.extend({
-    config: service(),
+export default class DesignsandboxRoute extends Route {
+    @service config;
 
     beforeModel() {
-        this._super(...arguments);
-        if (!this.get('config.enableDeveloperExperiments')) {
+        super.beforeModel(...arguments);
+        if (!this.config.get('enableDeveloperExperiments')) {
             return this.transitionTo('home');
         }
     }
-});
+}

--- a/app/routes/editor.js
+++ b/app/routes/editor.js
@@ -1,22 +1,16 @@
 import $ from 'jquery';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
-import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
-import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import {htmlSafe} from '@ember/template';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
-let generalShortcuts = {};
-generalShortcuts[`${ctrlOrCmd}+p`] = 'preview';
-
-export default AuthenticatedRoute.extend(ShortcutsRoute, {
+export default AuthenticatedRoute.extend({
     feature: service(),
     notifications: service(),
     userAgent: service(),
     ui: service(),
 
     classNames: ['editor'],
-    shortcuts: generalShortcuts,
 
     activate() {
         this._super(...arguments);
@@ -45,14 +39,6 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             this._blurAndScheduleAction(function () {
                 this.controller.send('save');
             });
-        },
-
-        preview() {
-            if (this.controller.post.isDraft) {
-                this.controller.send('openPostPreviewModal');
-            } else {
-                window.open(this.controller.post.previewUrl, '_blank', 'noopener');
-            }
         },
 
         authorizationFailed() {

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -1,9 +1,9 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {pluralize} from 'ember-inflector';
 
-export default AuthenticatedRoute.extend({
+export default class EditRoute extends AuthenticatedRoute {
     beforeModel(transition) {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
         // if the transition is not new->edit, reset the post on the controller
         // so that the editor view is cleared before showing the loading state
@@ -12,7 +12,7 @@ export default AuthenticatedRoute.extend({
             editor.set('post', null);
             editor.reset();
         }
-    },
+    }
 
     model(params, transition) {
         // eslint-disable-next-line camelcase
@@ -29,13 +29,13 @@ export default AuthenticatedRoute.extend({
 
         return this.store.query(modelName, query)
             .then(records => records.get('firstObject'));
-    },
+    }
 
     // the API will return a post even if the logged in user doesn't have
     // permission to edit it (all posts are public) so we need to do our
     // own permissions check and redirect if necessary
     afterModel(post) {
-        this._super(...arguments);
+        super.afterModel(...arguments);
 
         const user = this.session.user;
         const returnRoute = pluralize(post.constructor.modelName);
@@ -48,14 +48,14 @@ export default AuthenticatedRoute.extend({
         if (user.isContributor && !post.isDraft) {
             return this.replaceWith(returnRoute);
         }
-    },
+    }
 
     serialize(model) {
         return {
             type: model.constructor.modelName,
             post_id: model.id
         };
-    },
+    }
 
     // there's no specific controller for this route, instead all editor
     // handling is done on the editor route/controler
@@ -63,4 +63,4 @@ export default AuthenticatedRoute.extend({
         let editor = this.controllerFor('editor');
         editor.setPost(post);
     }
-});
+}

--- a/app/routes/editor/index.js
+++ b/app/routes/editor/index.js
@@ -1,8 +1,8 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
-export default AuthenticatedRoute.extend({
+export default class IndexRoute extends AuthenticatedRoute {
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
         this.replaceWith('editor.new', 'post');
     }
-});
+}

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -1,6 +1,6 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
-export default AuthenticatedRoute.extend({
+export default class NewRoute extends AuthenticatedRoute {
     model(params, transition) {
         let {type: modelName} = params;
 
@@ -10,18 +10,18 @@ export default AuthenticatedRoute.extend({
         }
 
         return this.store.createRecord(modelName, {authors: [this.session.user]});
-    },
+    }
 
     // there's no specific controller for this route, instead all editor
     // handling is done on the editor route/controler
     setupController(controller, newPost) {
         let editor = this.controllerFor('editor');
         editor.setPost(newPost);
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             mainClasses: ['editor-new']
         };
     }
-});
+}

--- a/app/routes/error404.js
+++ b/app/routes/error404.js
@@ -1,14 +1,14 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-    controllerName: 'error',
-    templateName: 'error',
+export default class Error404Route extends Route {
+    controllerName = 'error';
+    templateName = 'error';
 
     model() {
         return {
             status: 404
         };
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
@@ -16,4 +16,4 @@ export default Route.extend({
             mainClasses: ['gh-main-white']
         };
     }
-});
+}

--- a/app/routes/pages.js
+++ b/app/routes/pages.js
@@ -1,11 +1,11 @@
 import PostsRoute from './posts';
 
-export default PostsRoute.extend({
-    modelName: 'page',
+export default class PagesRoute extends PostsRoute {
+    modelName = 'page';
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Pages'
         };
     }
-});
+}

--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -1,27 +1,27 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import {action} from '@ember/object';
 import {assign} from '@ember/polyfills';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
-export default AuthenticatedRoute.extend({
-    infinity: service(),
-    router: service(),
+export default class PostsRoute extends AuthenticatedRoute {
+    @service infinity;
+    @service router;
 
-    queryParams: {
+    queryParams = {
         type: {refreshModel: true},
         visibility: {refreshModel: true},
         access: {refreshModel: true},
         author: {refreshModel: true},
         tag: {refreshModel: true},
         order: {refreshModel: true}
-    },
+    };
 
-    modelName: 'post',
+    modelName = 'post';
+    perPage = 30;
 
-    perPage: 30,
-
-    init() {
-        this._super(...arguments);
+    constructor() {
+        super(...arguments);
 
         // if we're already on this route and we're transiting _to_ this route
         // then the filters are being changed and we shouldn't create a new
@@ -35,7 +35,7 @@ export default AuthenticatedRoute.extend({
                 }
             }
         });
-    },
+    }
 
     model(params) {
         const user = this.session.user;
@@ -76,11 +76,11 @@ export default AuthenticatedRoute.extend({
         let paginationSettings = assign({perPage, startingPage: 1}, paginationParams, queryParams);
 
         return this.infinity.model(this.modelName, paginationSettings);
-    },
+    }
 
     // trigger a background load of all tags, authors, and snipps for use in filter dropdowns and card menu
     setupController(controller) {
-        this._super(...arguments);
+        super.setupController(...arguments);
 
         if (!controller._hasLoadedTags) {
             this.store.query('tag', {limit: 'all'}).then(() => {
@@ -99,25 +99,24 @@ export default AuthenticatedRoute.extend({
                 controller._hasLoadedSnippets = true;
             });
         }
-    },
+    }
 
-    actions: {
-        queryParamsDidChange() {
-            // scroll back to the top
-            let contentList = document.querySelector('.content-list');
-            if (contentList) {
-                contentList.scrollTop = 0;
-            }
-
-            this._super(...arguments);
+    @action
+    queryParamsDidChange() {
+        // scroll back to the top
+        let contentList = document.querySelector('.content-list');
+        if (contentList) {
+            contentList.scrollTop = 0;
         }
-    },
+
+        super.actions.queryParamsDidChange.call(this, ...arguments);
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Posts'
         };
-    },
+    }
 
     _getTypeFilters(type) {
         let status = '[draft,scheduled,published,sent]';
@@ -140,7 +139,7 @@ export default AuthenticatedRoute.extend({
         return {
             status
         };
-    },
+    }
 
     _filterString(filter) {
         return Object.keys(filter).map((key) => {
@@ -151,4 +150,4 @@ export default AuthenticatedRoute.extend({
             }
         }).compact().join('+');
     }
-});
+}

--- a/app/routes/pro.js
+++ b/app/routes/pro.js
@@ -1,18 +1,18 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
-// TODO: rename billing route and service to /pro
-export default AuthenticatedRoute.extend({
-    billing: service(),
-    session: service(),
-    config: service(),
+export default class ProRoute extends AuthenticatedRoute {
+    @service billing;
+    @service session;
+    @service config;
 
-    queryParams: {
+    queryParams = {
         action: {refreshModel: true}
-    },
+    };
 
     beforeModel(transition) {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
         // allow non-owner users to access the BMA when we're in a force upgrade state
         if (!this.session.user.isOwnerOnly && !this.config.get('hostSettings.forceUpgrade')) {
@@ -20,7 +20,7 @@ export default AuthenticatedRoute.extend({
         }
 
         this.billing.set('previousTransition', transition);
-    },
+    }
 
     model(params) {
         if (params.action) {
@@ -28,31 +28,30 @@ export default AuthenticatedRoute.extend({
         }
 
         this.billing.toggleProWindow(true);
-    },
+    }
 
-    actions: {
-        willTransition(transition) {
-            let isBillingTransition = false;
+    @action
+    willTransition(transition) {
+        let isBillingTransition = false;
 
-            if (transition) {
-                let destinationUrl = (typeof transition.to === 'string')
-                    ? transition.to
-                    : (transition.intent
-                        ? transition.intent.url
-                        : '');
+        if (transition) {
+            let destinationUrl = (typeof transition.to === 'string')
+                ? transition.to
+                : (transition.intent
+                    ? transition.intent.url
+                    : '');
 
-                if (destinationUrl?.includes('/pro')) {
-                    isBillingTransition = true;
-                }
+            if (destinationUrl?.includes('/pro')) {
+                isBillingTransition = true;
             }
-
-            this.billing.toggleProWindow(isBillingTransition);
         }
-    },
+
+        this.billing.toggleProWindow(isBillingTransition);
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Ghost(Pro)'
         };
     }
-});
+}

--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,25 +1,25 @@
 import UnauthenticatedRoute from 'ghost-admin/routes/unauthenticated';
 import {inject as service} from '@ember/service';
 
-export default UnauthenticatedRoute.extend({
-    notifications: service(),
-    session: service(),
+export default class ResetRoute extends UnauthenticatedRoute {
+    @service notifications;
+    @service session;
 
     beforeModel() {
-        if (this.get('session.isAuthenticated')) {
+        if (this.session.isAuthenticated) {
             this.notifications.showAlert('You can\'t reset your password while you\'re signed in.', {type: 'warn', delayed: true, key: 'password.reset.signed-in'});
         }
 
-        this._super(...arguments);
-    },
+        super.beforeModel(...arguments);
+    }
 
     setupController(controller, params) {
         controller.token = params.token;
-    },
+    }
 
     // Clear out any sensitive information
     deactivate() {
-        this._super(...arguments);
+        super.deactivate(...arguments);
         this.controller.clearData();
     }
-});
+}

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -1,11 +1,11 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject as service} from '@ember/service';
 
-export default AuthenticatedRoute.extend({
-    session: service(),
+export default class SettingsRoute extends AuthenticatedRoute {
+    @service session;
 
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
         const user = this.session.user;
 
@@ -13,4 +13,4 @@ export default AuthenticatedRoute.extend({
             return this.transitionTo('settings.staff.user', user);
         }
     }
-});
+}

--- a/app/routes/settings/integration/webhooks/edit.js
+++ b/app/routes/settings/integration/webhooks/edit.js
@@ -1,14 +1,14 @@
 import AdminRoute from 'ghost-admin/routes/admin';
 
-export default AdminRoute.extend({
+export default class EditRoute extends AdminRoute {
     model(params) {
         let integration = this.modelFor('settings.integration');
         let webhook = integration.webhooks.findBy('id', params.webhook_id);
         return webhook;
-    },
+    }
 
     deactivate() {
-        this._super(...arguments);
+        super.deactivate(...arguments);
         this.controller.reset();
     }
-});
+}

--- a/app/routes/settings/integration/webhooks/new.js
+++ b/app/routes/settings/integration/webhooks/new.js
@@ -1,13 +1,13 @@
 import AdminRoute from 'ghost-admin/routes/admin';
 
-export default AdminRoute.extend({
+export default class NewRoute extends AdminRoute {
     model() {
         let integration = this.modelFor('settings.integration');
         return this.store.createRecord('webhook', {integration});
-    },
+    }
 
     deactivate() {
-        this._super(...arguments);
+        super.deactivate(...arguments);
         this.controller.webhook.rollbackAttributes();
     }
-});
+}

--- a/app/routes/settings/integrations.js
+++ b/app/routes/settings/integrations.js
@@ -1,18 +1,18 @@
 import AdminRoute from 'ghost-admin/routes/admin';
 import {inject as service} from '@ember/service';
 
-export default AdminRoute.extend({
-    settings: service(),
+export default class IntegrationsRoute extends AdminRoute {
+    @service settings;
 
     setupController(controller) {
         // kick off the background fetch of integrations so that we can
         // show the screen immediately
         controller.fetchIntegrations.perform();
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Settings - Integrations'
         };
     }
-});
+}

--- a/app/routes/settings/integrations/zapier.js
+++ b/app/routes/settings/integrations/zapier.js
@@ -1,27 +1,27 @@
 import AdminRoute from 'ghost-admin/routes/admin';
 import {inject as service} from '@ember/service';
 
-export default AdminRoute.extend({
-    router: service(),
-    config: service(),
+export default class ZapierRoute extends AdminRoute {
+    @service router;
+    @service config;
 
-    init() {
-        this._super(...arguments);
+    constructor() {
+        super(...arguments);
         this.router.on('routeWillChange', () => {
             if (this.controller) {
                 this.controller.set('selectedApiKey', null);
                 this.controller.set('isApiKeyRegenerated', false);
             }
         });
-    },
+    }
 
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
         if (this.config.get('hostSettings.limits.customIntegrations.disabled')) {
             return this.transitionTo('settings.integrations');
         }
-    },
+    }
 
     model(params, transition) {
         // use the integrations controller to fetch all integrations and pick
@@ -30,11 +30,11 @@ export default AdminRoute.extend({
         return this
             .controllerFor('settings.integrations')
             .integrationModelHook('slug', 'zapier', this, transition);
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Zapier'
         };
     }
-});
+}

--- a/app/routes/settings/labs.js
+++ b/app/routes/settings/labs.js
@@ -1,23 +1,23 @@
 import AdminRoute from 'ghost-admin/routes/admin';
 import {inject as service} from '@ember/service';
 
-export default AdminRoute.extend({
-    settings: service(),
-    notifications: service(),
+export default class LabsRoute extends AdminRoute {
+    @service settings;
+    @service notifications;
 
     model() {
         return this.settings.reload();
-    },
+    }
 
     resetController(controller, isExiting) {
         if (isExiting) {
             controller.reset();
         }
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Settings - Labs'
         };
     }
-});
+}

--- a/app/routes/settings/members-email.js
+++ b/app/routes/settings/members-email.js
@@ -1,12 +1,13 @@
 import AdminRoute from 'ghost-admin/routes/admin';
+import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
-export default AdminRoute.extend({
-    notifications: service(),
-    settings: service(),
+export default class MembersEmailRoute extends AdminRoute {
+    @service notifications;
+    @service settings;
 
     beforeModel(transition) {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
         if (transition.to.queryParams?.fromAddressUpdate === 'success') {
             this.notifications.showAlert(
@@ -19,25 +20,24 @@ export default AdminRoute.extend({
                 {type: 'success', key: 'members.settings.support-address.updated'}
             );
         }
-    },
+    }
 
     model() {
         return this.settings.reload();
-    },
+    }
 
     setupController(controller) {
         controller.resetEmailAddresses();
-    },
+    }
 
-    actions: {
-        willTransition(transition) {
-            return this.controller.leaveRoute(transition);
-        }
-    },
+    @action
+    willTransition(transition) {
+        return this.controller.leaveRoute(transition);
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Settings - Members'
         };
     }
-});
+}

--- a/app/routes/settings/staff/index.js
+++ b/app/routes/settings/staff/index.js
@@ -1,28 +1,28 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
-export default AuthenticatedRoute.extend({
-    infinity: service(),
-    session: service(),
+export default class IndexRoute extends AuthenticatedRoute {
+    @service infinity;
+    @service session;
 
     model() {
         return this.session.user;
-    },
+    }
 
     setupController(controller) {
-        this._super(...arguments);
+        super.setupController(...arguments);
         controller.backgroundUpdate.perform();
-    },
+    }
 
-    actions: {
-        reload() {
-            this.controller.backgroundUpdate.perform();
-        }
-    },
+    @action
+    reload() {
+        this.controller.backgroundUpdate.perform();
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Staff'
         };
     }
-});
+}

--- a/app/routes/settings/staff/user.js
+++ b/app/routes/settings/staff/user.js
@@ -1,13 +1,14 @@
+import {action} from '@ember/object';
 /* eslint-disable camelcase */
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
-export default AuthenticatedRoute.extend({
+export default class UserRoute extends AuthenticatedRoute {
     model(params) {
         return this.store.queryRecord('user', {slug: params.user_slug, include: 'count.posts'});
-    },
+    }
 
     afterModel(user) {
-        this._super(...arguments);
+        super.afterModel(...arguments);
 
         const currentUser = this.session.user;
 
@@ -27,45 +28,46 @@ export default AuthenticatedRoute.extend({
                 this.controller.set('personalTokenRegenerated', false);
             });
         }
-    },
+    }
 
     serialize(model) {
         return {user_slug: model.get('slug')};
-    },
+    }
 
-    actions: {
-        didTransition() {
-            this.modelFor('settings.staff.user').get('errors').clear();
-        },
+    @action
+    didTransition() {
+        this.modelFor('settings.staff.user').get('errors').clear();
+    }
 
-        save() {
-            this.get('controller.save').perform();
-        },
+    @action
+    save() {
+        this.controller.save.perform();
+    }
 
-        willTransition(transition) {
-            let controller = this.controller;
-            let user = controller.user;
-            let dirtyAttributes = controller.dirtyAttributes;
-            let modelIsDirty = user.get('hasDirtyAttributes');
+    @action
+    willTransition(transition) {
+        let controller = this.controller;
+        let user = controller.user;
+        let dirtyAttributes = controller.dirtyAttributes;
+        let modelIsDirty = user.get('hasDirtyAttributes');
 
-            // always reset the password properties on the user model when leaving
-            if (user) {
-                user.set('password', '');
-                user.set('newPassword', '');
-                user.set('ne2Password', '');
-            }
-
-            if (modelIsDirty || dirtyAttributes) {
-                transition.abort();
-                controller.send('toggleLeaveSettingsModal', transition);
-                return;
-            }
+        // always reset the password properties on the user model when leaving
+        if (user) {
+            user.set('password', '');
+            user.set('newPassword', '');
+            user.set('ne2Password', '');
         }
-    },
+
+        if (modelIsDirty || dirtyAttributes) {
+            transition.abort();
+            controller.send('toggleLeaveSettingsModal', transition);
+            return;
+        }
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Staff - User'
         };
     }
-});
+}

--- a/app/routes/setup.js
+++ b/app/routes/setup.js
@@ -1,22 +1,22 @@
 import Route from '@ember/routing/route';
 import {inject as service} from '@ember/service';
 
-export default Route.extend({
-    ghostPaths: service(),
-    session: service(),
-    ajax: service(),
-    config: service(),
+export default class SetupRoute extends Route {
+    @service ghostPaths;
+    @service session;
+    @service ajax;
+    @service config;
 
     // use the beforeModel hook to check to see whether or not setup has been
     // previously completed.  If it has, stop the transition into the setup page.
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
-        if (this.get('session.isAuthenticated')) {
+        if (this.session.isAuthenticated) {
             return this.transitionTo('home');
         }
 
-        let authUrl = this.get('ghostPaths.url').api('authentication', 'setup');
+        let authUrl = this.ghostPaths.url.api('authentication', 'setup');
 
         // check the state of the setup process via the API
         return this.ajax.request(authUrl)
@@ -40,12 +40,12 @@ export default Route.extend({
                     }
                 }
             });
-    },
+    }
 
     deactivate() {
-        this._super(...arguments);
+        super.deactivate(...arguments);
         this.controllerFor('setup/two').set('password', '');
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
@@ -54,4 +54,4 @@ export default Route.extend({
             mainClasses: ['gh-main-white']
         };
     }
-});
+}

--- a/app/routes/setup/index.js
+++ b/app/routes/setup/index.js
@@ -1,8 +1,8 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class IndexRoute extends Route {
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
         this.transitionTo('setup.one');
     }
-});
+}

--- a/app/routes/setup/three.js
+++ b/app/routes/setup/three.js
@@ -1,10 +1,10 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class ThreeRoute extends Route {
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
         if (!this.controllerFor('setup.two').get('blogCreated')) {
             this.transitionTo('setup.two');
         }
     }
-});
+}

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -14,24 +14,24 @@ const defaultModel = function defaultModel() {
     });
 };
 
-export default UnauthenticatedRoute.extend({
+export default class SigninRoute extends UnauthenticatedRoute {
     model() {
         return defaultModel();
-    },
+    }
 
     // the deactivate hook is called after a route has been exited.
     deactivate() {
         let controller = this.controllerFor('signin');
 
-        this._super(...arguments);
+        super.deactivate(...arguments);
 
         // clear the properties that hold the credentials when we're no longer on the signin screen
         controller.set('signin', defaultModel());
-    },
+    }
 
     buildRouteInfoMetadata() {
-        return Object.assign(this._super(), {
+        return Object.assign(super.buildRouteInfoMetadata(), {
             titleToken: 'Sign In'
         });
     }
-});
+}

--- a/app/routes/signout.js
+++ b/app/routes/signout.js
@@ -1,17 +1,17 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject as service} from '@ember/service';
 
-export default AuthenticatedRoute.extend({
-    notifications: service(),
+export default class SignoutRoute extends AuthenticatedRoute {
+    @service notifications;
 
-    afterModel(/*model, transition*/) {
+    afterModel/*model, transition*/() {
         this.notifications.clearAll();
         this.session.invalidate();
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Sign Out'
         };
     }
-});
+}

--- a/app/routes/site.js
+++ b/app/routes/site.js
@@ -1,20 +1,20 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject as service} from '@ember/service';
 
-export default AuthenticatedRoute.extend({
-    config: service(),
-    settings: service(),
-    ui: service(),
+export default class SiteRoute extends AuthenticatedRoute {
+    @service config;
+    @service settings;
+    @service ui;
 
-    _hasLoggedIn: false,
+    _hasLoggedIn = false;
 
     model() {
         return (new Date()).valueOf();
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Site'
         };
     }
-});
+}

--- a/app/routes/tag/new.js
+++ b/app/routes/tag/new.js
@@ -1,6 +1,6 @@
 import TagRoute from '../tag';
 
-export default TagRoute.extend({
-    controllerName: 'tag',
-    templateName: 'tag'
-});
+export default class NewRoute extends TagRoute {
+    controllerName = 'tag';
+    templateName = 'tag';
+}

--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -1,21 +1,21 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
-export default AuthenticatedRoute.extend({
-    queryParams: {
+export default class TagsRoute extends AuthenticatedRoute {
+    queryParams = {
         type: {
             refreshModel: true,
             replace: true
         }
-    },
+    };
 
     // authors aren't allowed to manage tags
     beforeModel() {
-        this._super(...arguments);
+        super.beforeModel(...arguments);
 
         if (this.session.user.isAuthorOrContributor) {
             return this.transitionTo('home');
         }
-    },
+    }
 
     // set model to a live array so all tags are shown and created/deleted tags
     // are automatically added/removed. Also load all tags in the background,
@@ -28,11 +28,11 @@ export default AuthenticatedRoute.extend({
         } else {
             return tags;
         }
-    },
+    }
 
     buildRouteInfoMetadata() {
         return {
             titleToken: 'Tags'
         };
     }
-});
+}

--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -1,21 +1,11 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
-import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 
-export default AuthenticatedRoute.extend(ShortcutsRoute, {
+export default AuthenticatedRoute.extend({
     queryParams: {
         type: {
             refreshModel: true,
             replace: true
         }
-    },
-
-    shortcuts: null,
-
-    init() {
-        this._super(...arguments);
-        this.shortcuts = {
-            c: 'newTag'
-        };
     },
 
     // authors aren't allowed to manage tags
@@ -37,12 +27,6 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             return promise.then(() => tags);
         } else {
             return tags;
-        }
-    },
-
-    actions: {
-        newTag() {
-            this.transitionTo('tag.new');
         }
     },
 

--- a/app/routes/whatsnew.js
+++ b/app/routes/whatsnew.js
@@ -1,9 +1,9 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
-export default AuthenticatedRoute.extend({
+export default class WhatsnewRoute extends AuthenticatedRoute {
     buildRouteInfoMetadata() {
         return {
             titleToken: `What's new?`
         };
     }
-});
+}

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -1,5 +1,5 @@
 {{#if this.post}}
-    <div class="flex flex-row">
+    <div class="flex flex-row" {{on-key "cmd+p" (action "openPostPreview")}}>
         <GhEditor
             @tagName="section"
             @class="gh-editor gh-view relative"

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -1,4 +1,4 @@
-<section class="gh-canvas">
+<section class="gh-canvas" {{on-key "c" (action "newTag")}}>
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>Tags</h2>
         <section class="view-actions">


### PR DESCRIPTION
no issue

- refactored use of `ShortcutsRoute` mixin on Editor and Tags screen as there is a simple replacement through the `{{on-key}}` modifier
    - mixins are deprecated and aren't compatible with native class syntax without using the `@classic` decorator and having a mix of true native-class and EmberObject in the same file
- migrated route objects to native class syntax 
    - modern Ember uses native classes rather than EmberObject-based objects, this brings us closer to normalizing our code style across the codebase
    - ran the `ember-native-class-codemod` codemod to convert just the route classes to native class syntax and performed some minor manual cleanup
    - skipped the Application route as that requires deeper testing with a replacement for the `ShortcutsRoute` mixin