### PR TITLE
Refined database warning message to reflect specific versions

### DIFF
--- a/app/controllers/whatsnew.js
+++ b/app/controllers/whatsnew.js
@@ -13,12 +13,19 @@ export default class WhatsNewController extends Controller {
         return date.getFullYear();
     }
 
-    get showDatabaseWarning() {
+    get databaseWarning() {
         const isProduction = !!this.config.get('environment').match?.(/production/i);
         const isPro = !!this.config.get('hostSettings')?.siteId;
+        const database = this.config.get('database');
 
-        if (isProduction && !isPro) {
-            return true;
+        // Show a warning if we're in production and not using MySQL 8
+        if (isProduction && !isPro && database !== 'mysql8') {
+            return 'MySQL 8 will be the required database in the next major release of Ghost.';
+        }
+
+        // Show a warning if we're in development and using MySQL 5
+        if (!isProduction && !isPro && database === 'mysql5') {
+            return 'MySQL 5 will no longer be supported in the next major release of Ghost.';
         }
 
         return false;

--- a/app/templates/whatsnew.hbs
+++ b/app/templates/whatsnew.hbs
@@ -59,10 +59,10 @@
                     {{/if}}
                 </ul>
 
-                {{#if this.showDatabaseWarning}}
+                {{#if this.databaseWarning}}
                     <section class="gh-upgrade-notification">
                         <p>
-                            <strong>Warning:</strong> MySQL 8 will be the required database in the next major release of Ghost. Make sure your database is up to date to ensure forwards compatibility.
+                            <strong>Warning:</strong> {{this.databaseWarning}} Make sure your database is up to date to ensure forwards compatibility.
                         </p>
                     </section>
                 {{/if}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/175
refs https://github.com/TryGhost/Admin/commit/cf78595b1d97c7ce79c0570a42603bcfac803998

- the referenced commit added a warning message to the What's New page
  to notify the user that we're going to be requiring MySQL 8 in
  production as of v5
- this would also show if the user was already using MySQL 8, which
  isn't ideal
- I've added a library to Ghost which will return the specific version
  of MySQL used, so we can now detect that
- https://github.com/TryGhost/Ghost/commit/eb68e8d339ae447eafd9aa48d957a607252f7e4f has updated the config endpoint to return `mysql5`, `mysql8` etc,
  so we can now change the logic here to reflect that
- this commit also adds another warning if we're in development mode and
  using mysql5, as this will not be supported as of v5