### PR TITLE
Ran `ember-cli-update --run-codemods`

### DIFF
--- a/app/components/gh-billing-update-button.js
+++ b/app/components/gh-billing-update-button.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import {computed} from '@ember/object';
+import {reads} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 
 export default Component.extend({
@@ -11,7 +11,7 @@ export default Component.extend({
 
     subscription: null,
 
-    showUpgradeButton: computed.reads('billing.subscription.isActiveTrial'),
+    showUpgradeButton: reads('billing.subscription.isActiveTrial'),
 
     actions: {
         openBilling() {

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -6,12 +6,10 @@ import {
     isUnsupportedMediaTypeError,
     isVersionMismatchError
 } from 'ghost-admin/services/ajax';
-import {computed} from '@ember/object';
-import {get} from '@ember/object';
+import {computed, get} from '@ember/object';
 import {htmlSafe} from '@ember/template';
 import {isArray} from '@ember/array';
 import {isBlank} from '@ember/utils';
-import {isArray as isEmberArray} from '@ember/array';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
@@ -304,7 +302,7 @@ export default Component.extend({
         let extensions = this.extensions;
         let [, extension] = (/(?:\.([^.]+))?$/).exec(file.name);
 
-        if (!isEmberArray(extensions)) {
+        if (!isArray(extensions)) {
             extensions = extensions.split(',');
         }
 

--- a/app/components/gh-members-chart.js
+++ b/app/components/gh-members-chart.js
@@ -1,8 +1,7 @@
 /* global Chart */
 import Component from '@ember/component';
 import moment from 'moment';
-import {action} from '@ember/object';
-import {computed, get} from '@ember/object';
+import {action, computed, get} from '@ember/object';
 import {getSymbol} from 'ghost-admin/utils/currency';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -299,7 +298,7 @@ export default Component.extend({
         };
 
         if (this.chartType === 'mrr' || this.chartType === 'all-members') {
-            const chartData = this.get('chartData').datasets[0].data;
+            const chartData = this.chartData.datasets[0].data;
             let allZeros = true;
             for (let i = 0; i < chartData.length; i++) {
                 const element = chartData[i];

--- a/app/components/gh-members-email-setting.js
+++ b/app/components/gh-members-email-setting.js
@@ -115,7 +115,7 @@ export default Component.extend({
             if (event) {
                 event.preventDefault();
             }
-            this.set('settings.emailTrackOpens', !this.get('emailTrackOpens'));
+            this.set('settings.emailTrackOpens', !this.emailTrackOpens);
         },
 
         setReplyAddress(event) {

--- a/app/components/gh-members-payments-setting.js
+++ b/app/components/gh-members-payments-setting.js
@@ -36,7 +36,7 @@ export default Component.extend({
     stripeConnectLivemode: reads('settings.stripeConnectLivemode'),
 
     selectedCurrency: computed('stripePlans.monthly.currency', function () {
-        return this.get('currencies').findBy('value', this.get('stripePlans.monthly.currency')) || this.get('topCurrencies').findBy('value', this.get('stripePlans.monthly.currency'));
+        return this.currencies.findBy('value', this.get('stripePlans.monthly.currency')) || this.topCurrencies.findBy('value', this.get('stripePlans.monthly.currency'));
     }),
 
     stripePlans: computed('settings.stripePlans', function () {
@@ -79,15 +79,15 @@ export default Component.extend({
         this.set('allCurrencies', [
             {
                 groupName: '—',
-                options: this.get('topCurrencies')
+                options: this.topCurrencies
             },
             {
                 groupName: '—',
-                options: this.get('currencies')
+                options: this.currencies
             }
         ]);
 
-        if (this.get('stripeConnectAccountId')) {
+        if (this.stripeConnectAccountId) {
             this.set('membersStripeOpen', false);
         } else {
             this.set('membersStripeOpen', true);
@@ -166,10 +166,10 @@ export default Component.extend({
         this.get('settings.hasValidated').removeObject('stripePlans');
 
         if (this._scratchStripeYearlyAmount === null) {
-            this._scratchStripeYearlyAmount = this.get('stripePlans').yearly.amount;
+            this._scratchStripeYearlyAmount = this.stripePlans.yearly.amount;
         }
         if (this._scratchStripeMonthlyAmount === null) {
-            this._scratchStripeMonthlyAmount = this.get('stripePlans').monthly.amount;
+            this._scratchStripeMonthlyAmount = this.stripePlans.monthly.amount;
         }
 
         try {
@@ -210,7 +210,7 @@ export default Component.extend({
 
     openDisconnectStripeConnectModal: task(function* () {
         this.set('hasActiveStripeSubscriptions', false);
-        if (!this.get('stripeConnectAccountId')) {
+        if (!this.stripeConnectAccountId) {
             return;
         }
         const url = this.get('ghostPaths.url').api('/members/hasActiveStripeSubscriptions');

--- a/app/components/gh-nav-menu/main.js
+++ b/app/components/gh-nav-menu/main.js
@@ -1,8 +1,7 @@
 import Component from '@ember/component';
 import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
-import {and, equal, match, or} from '@ember/object/computed';
-import {computed} from '@ember/object';
+import {and, equal, match, or, reads} from '@ember/object/computed';
 import {getOwner} from '@ember/application';
 import {htmlSafe} from '@ember/template';
 import {inject as service} from '@ember/service';
@@ -41,8 +40,8 @@ export default Component.extend(ShortcutsMixin, {
     showTagsNavigation: or('session.user.isAdmin', 'session.user.isEditor'),
     showMenuExtension: and('config.clientExtensions.menu', 'session.user.isOwnerOnly'),
     showScriptExtension: and('config.clientExtensions.script', 'session.user.isOwnerOnly'),
-    showBilling: computed.reads('config.hostSettings.billing.enabled'),
-    isStripeConnected: computed.reads('settings.stripeConnectAccountId'),
+    showBilling: reads('config.hostSettings.billing.enabled'),
+    isStripeConnected: reads('settings.stripeConnectAccountId'),
 
     init() {
         this._super(...arguments);

--- a/app/components/gh-portal-links.js
+++ b/app/components/gh-portal-links.js
@@ -24,7 +24,7 @@ export default Component.extend({
         return this.isLink ? 'Link' : 'Data attribute';
     }),
     selectedProductIdPath: computed('selectedProduct', function () {
-        const selectedProduct = this.get('selectedProduct');
+        const selectedProduct = this.selectedProduct;
         if (selectedProduct) {
             return `/${selectedProduct.name}`;
         }
@@ -32,8 +32,8 @@ export default Component.extend({
     }),
 
     productOptions: computed('products.[]', function () {
-        if (this.get('products')) {
-            return this.get('products').map((product) => {
+        if (this.products) {
+            return this.products.map((product) => {
                 return {
                     label: product.name,
                     name: product.id

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -1,9 +1,8 @@
 import Component from '@ember/component';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import moment from 'moment';
-import {action} from '@ember/object';
+import {action, computed} from '@ember/object';
 import {alias, or} from '@ember/object/computed';
-import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default Component.extend({

--- a/app/components/gh-post-settings-menu/email.js
+++ b/app/components/gh-post-settings-menu/email.js
@@ -1,9 +1,8 @@
 import Component from '@ember/component';
 import EmailFailedError from 'ghost-admin/errors/email-failed-error';
 import validator from 'validator';
-import {action} from '@ember/object';
+import {action, computed} from '@ember/object';
 import {alias, not, oneWay, or} from '@ember/object/computed';
-import {computed} from '@ember/object';
 import {htmlSafe} from '@ember/template';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
@@ -78,7 +77,7 @@ export default Component.extend({
                 this.set('sendTestEmailError', 'Please enter a valid email');
                 return false;
             }
-            if (!this.get('mailgunIsEnabled')) {
+            if (!this.mailgunIsEnabled) {
                 this.set('sendTestEmailError', 'Please verify your email settings');
                 return false;
             }

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -1,9 +1,8 @@
 import Component from '@ember/component';
 import EmailFailedError from 'ghost-admin/errors/email-failed-error';
-import {bind} from '@ember/runloop';
+import {bind, schedule} from '@ember/runloop';
 import {computed} from '@ember/object';
 import {or, reads} from '@ember/object/computed';
-import {schedule} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
@@ -305,7 +304,7 @@ export default Component.extend({
     },
 
     setDefaultSendEmailWhenPublished() {
-        if (this.get('isSendingEmailLimited')) {
+        if (this.isSendingEmailLimited) {
             this.set('sendEmailWhenPublished', false);
         } else if (this.postStatus === 'draft' && this.canSendEmail) {
             // Set default newsletter recipients

--- a/app/components/gh-tag-settings-form.js
+++ b/app/components/gh-tag-settings-form.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import Ember from 'ember';
-import {action} from '@ember/object';
-import {computed} from '@ember/object';
+import {action, computed} from '@ember/object';
 import {htmlSafe} from '@ember/template';
 import {or} from '@ember/object/computed';
 import {run} from '@ember/runloop';

--- a/app/components/gh-theme-table.js
+++ b/app/components/gh-theme-table.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
-import {action} from '@ember/object';
-import {get} from '@ember/object';
+import {action, get} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default class GhThemeTableComponent extends Component {

--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import EmberObject from '@ember/object';
+import EmberObject, {get} from '@ember/object';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {
     ICON_EXTENSIONS,
@@ -8,7 +8,6 @@ import {
     IMAGE_MIME_TYPES
 } from 'ghost-admin/components/gh-image-uploader';
 import {all, task} from 'ember-concurrency';
-import {get} from '@ember/object';
 import {isArray} from '@ember/array';
 import {isEmpty} from '@ember/utils';
 import {run} from '@ember/runloop';

--- a/app/components/modal-add-label-members.js
+++ b/app/components/modal-add-label-members.js
@@ -1,6 +1,5 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
-import {alias} from '@ember/object/computed';
-import {not} from '@ember/object/computed';
+import {alias, not} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modal-delete-member.js
+++ b/app/components/modal-delete-member.js
@@ -1,7 +1,6 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
-import {alias} from '@ember/object/computed';
+import {alias, reads} from '@ember/object/computed';
 import {computed} from '@ember/object';
-import {reads} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modal-delete-members.js
+++ b/app/components/modal-delete-members.js
@@ -17,7 +17,7 @@ export default ModalComponent.extend({
 
     deleteMembersTask: task(function* () {
         try {
-            this.set('response', yield this.confirm());
+            this.set('response', (yield this.confirm()));
             this.set('confirmed', true);
         } catch (e) {
             if (e.payload?.errors) {

--- a/app/components/modal-impersonate-member.js
+++ b/app/components/modal-impersonate-member.js
@@ -25,7 +25,7 @@ export default ModalComponent.extend({
     },
 
     copySigninUrl: task(function* () {
-        copyTextToClipboard(this.get('signinUrl'));
+        copyTextToClipboard(this.signinUrl);
         yield timeout(1000);
         return true;
     }),

--- a/app/components/modal-members-label-form.js
+++ b/app/components/modal-members-label-form.js
@@ -1,5 +1,5 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
-import {computed} from '@ember/object';
+import {and} from '@ember/object/computed';
 import {resetQueryParams} from 'ghost-admin/helpers/reset-query-params';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -11,7 +11,7 @@ export default ModalComponent.extend({
     showDeleteLabelModal: false,
 
     confirm() {},
-    label: computed.and('model', 'model.label'),
+    label: and('model', 'model.label'),
 
     willDestroyElement() {
         this._super(...arguments);

--- a/app/components/modal-portal-settings.js
+++ b/app/components/modal-portal-settings.js
@@ -88,7 +88,7 @@ export default ModalComponent.extend({
     }),
 
     showPortalTiers: computed('products', 'feature.multipleProducts', function () {
-        return this.get('products')?.length > 1 && this.feature.get('multipleProducts');
+        return this.products?.length > 1 && this.feature.get('multipleProducts');
     }),
 
     init() {
@@ -206,11 +206,11 @@ export default ModalComponent.extend({
         },
 
         validateFreeSignupRedirect() {
-            return this._validateSignupRedirect(this.get('freeSignupRedirect'), 'membersFreeSignupRedirect');
+            return this._validateSignupRedirect(this.freeSignupRedirect, 'membersFreeSignupRedirect');
         },
 
         validatePaidSignupRedirect() {
-            return this._validateSignupRedirect(this.get('paidSignupRedirect'), 'membersPaidSignupRedirect');
+            return this._validateSignupRedirect(this.paidSignupRedirect, 'membersPaidSignupRedirect');
         }
     },
 

--- a/app/components/modal-product-price.js
+++ b/app/components/modal-product-price.js
@@ -37,11 +37,11 @@ export default class ModalProductPrice extends ModalBase {
         this.allCurrencies = [
             {
                 groupName: '—',
-                options: this.get('topCurrencies')
+                options: this.topCurrencies
             },
             {
                 groupName: '—',
-                options: this.get('currencies')
+                options: this.currencies
             }
         ];
         this.currencyVal = this.price.currency || 'usd';

--- a/app/components/modal-remove-label-members.js
+++ b/app/components/modal-remove-label-members.js
@@ -1,6 +1,5 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
-import {alias} from '@ember/object/computed';
-import {not} from '@ember/object/computed';
+import {alias, not} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modals/editor/confirm-publish.js
+++ b/app/components/modals/editor/confirm-publish.js
@@ -68,8 +68,8 @@ export default class ModalsEditorConfirmPublishComponent extends Component {
 
         const filter = `subscribed:true+(${sendEmailWhenPublished})`;
 
-        this.memberCount = sendEmailWhenPublished ? yield this.membersCountCache.count(filter) : 0;
-        this.memberCountString = sendEmailWhenPublished ? yield this.membersCountCache.countString(filter) : '0 members';
+        this.memberCount = sendEmailWhenPublished ? (yield this.membersCountCache.count(filter)) : 0;
+        this.memberCountString = sendEmailWhenPublished ? (yield this.membersCountCache.countString(filter)) : '0 members';
     }
 
     @task

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import Controller from '@ember/controller';
 import {computed} from '@ember/object';
+import {reads} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 
 export default Controller.extend({
@@ -14,7 +15,7 @@ export default Controller.extend({
     settings: service(),
     ui: service(),
 
-    showBilling: computed.reads('config.hostSettings.billing.enabled'),
+    showBilling: reads('config.hostSettings.billing.enabled'),
     showNavMenu: computed('router.currentRouteName', 'session.{isAuthenticated,user}', 'ui.isFullScreen', function () {
         let {router, session, ui} = this;
 

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -1,20 +1,17 @@
-import Controller from '@ember/controller';
+import Controller, {inject as controller} from '@ember/controller';
 import PostModel from 'ghost-admin/models/post';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import config from 'ghost-admin/config/environment';
 import isNumber from 'ghost-admin/utils/isNumber';
 import moment from 'moment';
-import {action, computed} from '@ember/object';
+import {action, computed, get} from '@ember/object';
 import {alias, mapBy} from '@ember/object/computed';
 import {capitalize} from '@ember/string';
-import {inject as controller} from '@ember/controller';
-import {get} from '@ember/object';
 import {htmlSafe} from '@ember/template';
 import {isBlank} from '@ember/utils';
 import {isArray as isEmberArray} from '@ember/array';
-import {isHostLimitError, isServerUnreachableError} from 'ghost-admin/services/ajax';
+import {isHostLimitError, isServerUnreachableError, isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {isInvalidError} from 'ember-ajax/errors';
-import {isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {inject as service} from '@ember/service';
 import {task, taskGroup, timeout} from 'ember-concurrency';
 

--- a/app/controllers/members/import.js
+++ b/app/controllers/members/import.js
@@ -1,6 +1,5 @@
-import Controller from '@ember/controller';
+import Controller, {inject as controller} from '@ember/controller';
 import {action} from '@ember/object';
-import {inject as controller} from '@ember/controller';
 import {resetQueryParams} from 'ghost-admin/helpers/reset-query-params';
 import {inject as service} from '@ember/service';
 

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -1,8 +1,7 @@
 import Controller from '@ember/controller';
 import {DEFAULT_QUERY_PARAMS} from 'ghost-admin/helpers/reset-query-params';
 import {alias} from '@ember/object/computed';
-import {computed} from '@ember/object';
-import {get} from '@ember/object';
+import {computed, get} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 const TYPES = [{
@@ -81,32 +80,32 @@ export default Controller.extend({
     postsInfinityModel: alias('model'),
 
     showingAll: computed('type', 'author', 'tag', function () {
-        let {type, author, tag, visibility} = this.getProperties(['type', 'visibility', 'author', 'tag']);
+        let {type, author, tag, visibility} = this;
 
         return !type && !visibility && !author && !tag;
     }),
 
     selectedType: computed('type', function () {
-        let types = this.get('availableTypes');
-        return types.findBy('value', this.get('type')) || {value: '!unknown'};
+        let types = this.availableTypes;
+        return types.findBy('value', this.type) || {value: '!unknown'};
     }),
 
     selectedVisibility: computed('visibility', function () {
-        let visibilities = this.get('availableVisibilities');
-        return visibilities.findBy('value', this.get('visibility')) || {value: '!unknown'};
+        let visibilities = this.availableVisibilities;
+        return visibilities.findBy('value', this.visibility) || {value: '!unknown'};
     }),
 
     selectedOrder: computed('order', function () {
-        let orders = this.get('availableOrders');
-        return orders.findBy('value', this.get('order')) || {value: '!unknown'};
+        let orders = this.availableOrders;
+        return orders.findBy('value', this.order) || {value: '!unknown'};
     }),
 
     _availableTags: computed(function () {
-        return this.get('store').peekAll('tag');
+        return this.store.peekAll('tag');
     }),
 
     availableTags: computed('_availableTags.[]', function () {
-        let tags = this.get('_availableTags')
+        let tags = this._availableTags
             .filter(tag => tag.get('id') !== null)
             .sort((tagA, tagB) => tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true}));
         let options = tags.toArray();
@@ -116,18 +115,18 @@ export default Controller.extend({
     }),
 
     selectedTag: computed('tag', '_availableTags.[]', function () {
-        let tag = this.get('tag');
-        let tags = this.get('availableTags');
+        let tag = this.tag;
+        let tags = this.availableTags;
 
         return tags.findBy('slug', tag) || {slug: '!unknown'};
     }),
 
     _availableAuthors: computed(function () {
-        return this.get('store').peekAll('user');
+        return this.store.peekAll('user');
     }),
 
     availableAuthors: computed('_availableAuthors.[]', function () {
-        let authors = this.get('_availableAuthors');
+        let authors = this._availableAuthors;
         let options = authors.toArray();
 
         options.unshiftObject({name: 'All authors', slug: null});
@@ -136,8 +135,8 @@ export default Controller.extend({
     }),
 
     selectedAuthor: computed('author', 'availableAuthors.[]', function () {
-        let author = this.get('author');
-        let authors = this.get('availableAuthors');
+        let author = this.author;
+        let authors = this.availableAuthors;
 
         return authors.findBy('slug', author) || {slug: '!unknown'};
     }),

--- a/app/controllers/settings/staff/index.js
+++ b/app/controllers/settings/staff/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import Controller from '@ember/controller';
 import RSVP from 'rsvp';
-import {alias, sort} from '@ember/object/computed';
+import {alias, filterBy, sort} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -28,7 +28,7 @@ export default Controller.extend({
     sortedActiveUsers: sort('activeUsers', 'userOrder'),
     sortedSuspendedUsers: sort('suspendedUsers', 'userOrder'),
 
-    filteredInvites: computed.filterBy('invites', 'isNew', false),
+    filteredInvites: filterBy('invites', 'isNew', false),
 
     invites: computed(function () {
         return this.store.peekAll('invite');

--- a/app/controllers/tag.js
+++ b/app/controllers/tag.js
@@ -1,8 +1,7 @@
 import Controller from '@ember/controller';
-import EmberObject from '@ember/object';
+import EmberObject, {computed, defineProperty} from '@ember/object';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import {alias} from '@ember/object/computed';
-import {computed, defineProperty} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {slugify} from '@tryghost/string';
 import {task} from 'ember-concurrency';

--- a/app/models/invite.js
+++ b/app/models/invite.js
@@ -24,7 +24,7 @@ export default Model.extend({
 
         let inviteUrl = this.get('ghostPaths.url').api('invites');
 
-        return this.ajax.del(`${inviteUrl}${this.get('id')}`)
+        return this.ajax.del(`${inviteUrl}${this.id}`)
             .then(() => {
                 return this.ajax.post(inviteUrl, {
                     data: JSON.stringify({invites: [inviteData]}),

--- a/app/models/member.js
+++ b/app/models/member.js
@@ -40,7 +40,7 @@ export default Model.extend(ValidationEngine, {
     },
 
     fetchSigninUrl: task(function* () {
-        let url = this.get('ghostPaths.url').api('members', this.get('id'), 'signin_urls');
+        let url = this.get('ghostPaths.url').api('members', this.id, 'signin_urls');
 
         let response = yield this.ajax.request(url);
 

--- a/app/models/navigation-item.js
+++ b/app/models/navigation-item.js
@@ -1,6 +1,5 @@
-import EmberObject from '@ember/object';
+import EmberObject, {computed} from '@ember/object';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
-import {computed} from '@ember/object';
 import {isBlank} from '@ember/utils';
 
 export default EmberObject.extend(ValidationEngine, {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -3,12 +3,11 @@ import Model, {attr, belongsTo, hasMany} from '@ember-data/model';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import moment from 'moment';
-import {compare} from '@ember/utils';
+import {compare, isBlank} from '@ember/utils';
 // eslint-disable-next-line ghost/ember/no-observers
 import {BLANK_DOC} from 'koenig-editor/components/koenig-editor';
 import {computed, observer} from '@ember/object';
 import {equal, filterBy, reads} from '@ember/object/computed';
-import {isBlank} from '@ember/utils';
 import {on} from '@ember/object/evented';
 import {inject as service} from '@ember/service';
 

--- a/app/models/product-benefit-item.js
+++ b/app/models/product-benefit-item.js
@@ -1,6 +1,5 @@
-import EmberObject from '@ember/object';
+import EmberObject, {computed} from '@ember/object';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
-import {computed} from '@ember/object';
 import {isBlank} from '@ember/utils';
 
 export default EmberObject.extend(ValidationEngine, {

--- a/app/models/slack-integration.js
+++ b/app/models/slack-integration.js
@@ -1,6 +1,5 @@
-import EmberObject from '@ember/object';
+import EmberObject, {computed} from '@ember/object';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
-import {computed} from '@ember/object';
 import {isBlank} from '@ember/utils';
 
 export default EmberObject.extend(ValidationEngine, {

--- a/app/services/billing.js
+++ b/app/services/billing.js
@@ -1,5 +1,4 @@
-import Service from '@ember/service';
-import {inject as service} from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 
 export default Service.extend({
     router: service(),
@@ -27,8 +26,8 @@ export default Service.extend({
     },
 
     handleRouteChangeInIframe(destinationRoute) {
-        if (this.get('billingWindowOpen')) {
-            let billingRoute = this.get('billingRouteRoot');
+        if (this.billingWindowOpen) {
+            let billingRoute = this.billingRouteRoot;
 
             if (destinationRoute !== '/') {
                 billingRoute += destinationRoute;
@@ -46,8 +45,8 @@ export default Service.extend({
 
         let url = this.config.get('hostSettings.billing.url');
 
-        if (window.location.hash && window.location.hash.includes(this.get('billingRouteRoot'))) {
-            let destinationRoute = window.location.hash.replace(this.get('billingRouteRoot'), '');
+        if (window.location.hash && window.location.hash.includes(this.billingRouteRoot)) {
+            let destinationRoute = window.location.hash.replace(this.billingRouteRoot, '');
 
             if (destinationRoute) {
                 url += destinationRoute;
@@ -58,7 +57,7 @@ export default Service.extend({
     },
 
     async getOwnerUser() {
-        if (!this.get('ownerUser')) {
+        if (!this.ownerUser) {
             // Try to receive the owner user from the store
             let user = this.store.peekAll('user').findBy('isOwnerOnly', true);
 
@@ -69,19 +68,19 @@ export default Service.extend({
             }
             this.set('ownerUser', user);
         }
-        return this.get('ownerUser');
+        return this.ownerUser;
     },
 
     // Sends a route update to a child route in the BMA, because we can't control
     // navigating to it otherwise
     sendRouteUpdate() {
-        const action = this.get('action');
+        const action = this.action;
 
         if (action) {
             if (action === 'checkout') {
                 this.getBillingIframe().contentWindow.postMessage({
                     query: 'routeUpdate',
-                    response: this.get('checkoutRoute')
+                    response: this.checkoutRoute
                 }, '*');
             }
 
@@ -93,7 +92,7 @@ export default Service.extend({
     // and the URL opened on the iframe. It is responsible to non user triggered iframe opening,
     // for example: by entering "/pro" route in the URL or using history navigation (back and forward)
     toggleProWindow(value) {
-        if (this.get('billingWindowOpen') && value && !this.get('action')) {
+        if (this.billingWindowOpen && value && !this.action) {
             // don't attempt to open again
             return;
         }
@@ -111,7 +110,7 @@ export default Service.extend({
         // initiate getting owner user in the background
         this.getOwnerUser();
 
-        if (this.get('billingWindowOpen')) {
+        if (this.billingWindowOpen) {
             // don't attempt to open again
             return;
         }

--- a/app/services/custom-theme-settings.js
+++ b/app/services/custom-theme-settings.js
@@ -1,7 +1,6 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import {isEmpty} from '@ember/utils';
 import {run} from '@ember/runloop';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 import {tracked} from '@glimmer/tracking';
 

--- a/app/services/custom-views.js
+++ b/app/services/custom-views.js
@@ -1,9 +1,8 @@
 import EmberObject, {action} from '@ember/object';
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import {isArray} from '@ember/array';
 import {observes} from '@ember-decorators/object';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 import {tracked} from '@glimmer/tracking';
 

--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -2,8 +2,7 @@ import $ from 'jquery';
 import Ember from 'ember';
 import EmberError from '@ember/error';
 import Service, {inject as service} from '@ember/service';
-import {computed} from '@ember/object';
-import {set} from '@ember/object';
+import {computed, set} from '@ember/object';
 
 export function feature(name, options = {}) {
     let {user, onChange} = options;

--- a/app/services/frontend.js
+++ b/app/services/frontend.js
@@ -1,7 +1,6 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import fetch from 'fetch';
 import validator from 'validator';
-import {inject as service} from '@ember/service';
 
 export default class FrontendService extends Service {
     @service settings;

--- a/app/services/members-activity.js
+++ b/app/services/members-activity.js
@@ -1,5 +1,4 @@
-import Service from '@ember/service';
-import {inject as service} from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 export default class MembersActivityService extends Service {
     @service ajax;

--- a/app/services/members-count-cache.js
+++ b/app/services/members-count-cache.js
@@ -1,7 +1,6 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import moment from 'moment';
 import {ghPluralize} from 'ghost-admin/helpers/gh-pluralize';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 
 export default class MembersCountCacheService extends Service {

--- a/app/services/members-stats.js
+++ b/app/services/members-stats.js
@@ -1,6 +1,5 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import moment from 'moment';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 import {tracked} from '@glimmer/tracking';
 

--- a/app/services/members-utils.js
+++ b/app/services/members-utils.js
@@ -1,5 +1,5 @@
-import Service from '@ember/service';
-import {inject as service} from '@ember/service';
+import Service, {inject as service} from '@ember/service';
+
 export default class MembersUtilsService extends Service {
     @service config;
     @service settings;

--- a/app/services/navigation.js
+++ b/app/services/navigation.js
@@ -1,8 +1,6 @@
-import Service from '@ember/service';
-import {action} from '@ember/object';
+import Service, {inject as service} from '@ember/service';
+import {action, set} from '@ember/object';
 import {observes} from '@ember-decorators/object';
-import {inject as service} from '@ember/service';
-import {set} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
 
 const DEFAULT_SETTINGS = {

--- a/app/services/tenor.js
+++ b/app/services/tenor.js
@@ -1,9 +1,8 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import fetch from 'fetch';
 import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {isEmpty} from '@ember/utils';
-import {inject as service} from '@ember/service';
 import {task, taskGroup} from 'ember-concurrency-decorators';
 import {timeout} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';

--- a/app/services/theme-management.js
+++ b/app/services/theme-management.js
@@ -1,9 +1,8 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import config from 'ghost-admin/config/environment';
 import {action} from '@ember/object';
 import {isEmpty} from '@ember/utils';
 import {isThemeValidationError} from 'ghost-admin/services/ajax';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency-decorators';
 import {tracked} from '@glimmer/tracking';
 

--- a/app/services/ui.js
+++ b/app/services/ui.js
@@ -4,8 +4,7 @@ import {
     darkenToContrastThreshold,
     lightenToContrastThreshold
 } from '@tryghost/color-utils';
-import {action} from '@ember/object';
-import {get} from '@ember/object';
+import {action, get} from '@ember/object';
 import {isEmpty} from '@ember/utils';
 import {tracked} from '@glimmer/tracking';
 

--- a/app/services/whats-new.js
+++ b/app/services/whats-new.js
@@ -1,10 +1,8 @@
-import Service from '@ember/service';
+import Service, {inject as service} from '@ember/service';
 import fetch from 'fetch';
 import moment from 'moment';
-import {action} from '@ember/object';
-import {computed} from '@ember/object';
+import {action, computed} from '@ember/object';
 import {isEmpty} from '@ember/utils';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
 export default Service.extend({

--- a/tests/acceptance/members-test.js
+++ b/tests/acceptance/members-test.js
@@ -1,8 +1,7 @@
 import moment from 'moment';
-import wait from 'ember-test-helpers/wait';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {beforeEach, describe, it} from 'mocha';
-import {blur, click, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
+import {blur, click, currentURL, fillIn, find, findAll, settled} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -48,8 +47,7 @@ describe('Acceptance: Members', function () {
 
             await visit('/members');
 
-            // second wait is needed for the vertical-collection to settle
-            await wait();
+            await settled();
 
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/members');
@@ -68,7 +66,7 @@ describe('Acceptance: Members', function () {
             await visit(`/members/${member1.id}`);
 
             // // second wait is needed for the member details to settle
-            await wait();
+            await settled();
 
             // it shows selected member form
             expect(find('[data-test-input="member-name"]').value, 'loads correct member into form')
@@ -89,8 +87,6 @@ describe('Acceptance: Members', function () {
 
             await click('[data-test-link="members-back"]');
 
-            await wait();
-
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/members');
         });
@@ -100,8 +96,7 @@ describe('Acceptance: Members', function () {
 
             await visit('/members');
 
-            // second wait is needed for the vertical-collection to settle
-            await wait();
+            await settled();
 
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/members');
@@ -136,8 +131,6 @@ describe('Acceptance: Members', function () {
             await blur('[data-test-input="member-email"]');
 
             await click('[data-test-button="save"]');
-
-            await wait();
 
             expect(find('[data-test-input="member-name"]').value, 'name has been preserved')
                 .to.equal('New Name');

--- a/tests/acceptance/offers-test.js
+++ b/tests/acceptance/offers-test.js
@@ -1,8 +1,7 @@
 import moment from 'moment';
-import wait from 'ember-test-helpers/wait';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {beforeEach, describe, it} from 'mocha';
-import {blur, click, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
+import {blur, click, currentURL, fillIn, find, findAll, settled} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -48,8 +47,7 @@ describe('Acceptance: Offers', function () {
 
             await visit('/offers');
 
-            // second wait is needed for the vertical-collection to settle
-            await wait();
+            await settled();
 
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/offers');
@@ -68,7 +66,7 @@ describe('Acceptance: Offers', function () {
             await visit(`/offers/${offer1.id}`);
 
             // second wait is needed for the offer details to settle
-            await wait();
+            await settled();
 
             // it shows selected offer form
             expect(find('[data-test-input="offer-name"]').value, 'loads correct offer into form')
@@ -85,8 +83,6 @@ describe('Acceptance: Offers', function () {
             await timeout(100);
 
             await click('[data-test-link="offers-back"]');
-
-            await wait();
 
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/offers');

--- a/tests/acceptance/settings/integrations-test.js
+++ b/tests/acceptance/settings/integrations-test.js
@@ -1,6 +1,6 @@
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {beforeEach, describe, it} from 'mocha';
-import {click, currentRouteName, currentURL, fillIn, find, findAll, triggerEvent} from '@ember/test-helpers';
+import {blur, click, currentRouteName, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -329,7 +329,7 @@ describe('Acceptance: Settings - Integrations - Custom', function () {
             ).to.be.empty;
 
             await fillIn('[data-test-input="name"]', '');
-            await triggerEvent('[data-test-input="name"]', 'blur');
+            await await blur('[data-test-input="name"]');
 
             expect(
                 find('[data-test-error="name"]').textContent,
@@ -344,7 +344,7 @@ describe('Acceptance: Settings - Integrations - Custom', function () {
             ).to.equal('Integration 1');
 
             await fillIn('[data-test-input="name"]', 'Test Integration');
-            await triggerEvent('[data-test-input="name"]', 'blur');
+            await await blur('[data-test-input="name"]');
 
             expect(
                 find('[data-test-error="name"]').textContent.trim(),
@@ -352,7 +352,7 @@ describe('Acceptance: Settings - Integrations - Custom', function () {
             ).to.be.empty;
 
             await fillIn('[data-test-input="description"]', 'Description for Test Integration');
-            await triggerEvent('[data-test-input="description"]', 'blur');
+            await await blur('[data-test-input="description"]');
             await click('[data-test-button="save"]');
 
             // changes are reflected in the integrations list
@@ -469,7 +469,7 @@ describe('Acceptance: Settings - Integrations - Custom', function () {
 
             await visit('/settings/integrations/1');
             await click('[data-test-input="description"]');
-            await triggerEvent('[data-test-input="description"]', 'blur');
+            await await blur('[data-test-input="description"]');
             await click('[data-test-link="integrations-back"]');
 
             expect(

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -1,9 +1,8 @@
-import wait from 'ember-test-helpers/wait';
 import windowProxy from 'ghost-admin/utils/window-proxy';
 import {Response} from 'ember-cli-mirage';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
-import {blur, click, currentRouteName, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
+import {blur, click, currentRouteName, currentURL, fillIn, find, findAll, settled} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
 import {setupApplicationTest} from 'ember-mocha';
@@ -95,9 +94,6 @@ describe.skip('Acceptance: Tags', function () {
 
             await visit('/tags');
 
-            // second wait is needed for the vertical-collection to settle
-            await wait();
-
             // it redirects to first tag
             // expect(currentURL(), 'currentURL').to.equal(`/tags/${tag1.slug}`);
 
@@ -125,7 +121,6 @@ describe.skip('Acceptance: Tags', function () {
             await visit(`/tags/${tag1.slug}`);
 
             // second wait is needed for the tag details to settle
-            await wait();
 
             // it shows selected tag form
             // expect(find('.tag-settings-pane h4').textContent, 'settings pane title')
@@ -154,7 +149,7 @@ describe.skip('Acceptance: Tags', function () {
                 keyup(38);
             });
 
-            await wait();
+            await settled();
 
             // it navigates to previous tag
             expect(currentURL(), 'url after keyboard up arrow').to.equal(`/tags/${tag1.slug}`);
@@ -169,7 +164,7 @@ describe.skip('Acceptance: Tags', function () {
                 keyup(40);
             });
 
-            await wait();
+            await settled();
 
             // it navigates to previous tag
             expect(currentURL(), 'url after keyboard down arrow').to.equal(`/tags/${tag2.slug}`);
@@ -255,9 +250,6 @@ describe.skip('Acceptance: Tags', function () {
 
             await visit('/tags/tag-1');
 
-            // second wait is needed for the vertical-collection to settle
-            await wait();
-
             expect(currentURL(), 'URL after direct load').to.equal('/tags/tag-1');
 
             // it loads all other tags
@@ -278,9 +270,6 @@ describe.skip('Acceptance: Tags', function () {
 
             await visit('tags/');
 
-            // second wait is needed for the vertical-collection to settle
-            await wait();
-
             expect(currentURL()).to.equal('/tags/hash-internal-tag');
 
             expect(findAll('.settings-tags .settings-tag').length, 'tag list count')
@@ -299,9 +288,6 @@ describe.skip('Acceptance: Tags', function () {
             this.server.createList('tag', 2);
 
             await visit('/tags/tag-1');
-
-            // second wait is needed for the vertical-collection to settle
-            await wait();
 
             expect(currentURL(), 'URL after direct load').to.equal('/tags/tag-1');
 
@@ -332,9 +318,6 @@ describe.skip('Acceptance: Tags', function () {
             this.server.create('tag', {name: 'A - First', slug: 'first'});
 
             await visit('tags');
-
-            // second wait is needed for the vertical-collection to settle
-            await wait();
 
             let tags = findAll('[data-test-tag]');
 

--- a/tests/integration/components/gh-cm-editor-test.js
+++ b/tests/integration/components/gh-cm-editor-test.js
@@ -21,7 +21,7 @@ describe('Integration: Component: gh-cm-editor', function () {
 
         await settled();
 
-        expect(this.get('text'), 'text value after CM editor change')
+        expect(this.text, 'text value after CM editor change')
             .to.equal('Testing');
     });
 

--- a/tests/integration/components/gh-navitem-test.js
+++ b/tests/integration/components/gh-navitem-test.js
@@ -53,7 +53,7 @@ describe('Integration: Component: gh-navitem', function () {
 
         let deleteActionCallCount = 0;
         this.set('deleteItem', (navItem) => {
-            expect(navItem).to.equal(this.get('navItem'));
+            expect(navItem).to.equal(this.navItem);
             deleteActionCallCount += 1;
         });
 
@@ -109,7 +109,7 @@ describe('Integration: Component: gh-navitem', function () {
 
     it('displays inline errors', async function () {
         this.set('navItem', NavItem.create({label: '', url: ''}));
-        this.get('navItem').validate();
+        this.navItem.validate();
 
         await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl}}`);
         let item = find('.gh-blognav-item');

--- a/tests/integration/components/gh-psm-template-select-test.js
+++ b/tests/integration/components/gh-psm-template-select-test.js
@@ -1,6 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
 import mockThemes from '../../../mirage/config/themes';
-import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {find, render} from '@ember/test-helpers';
@@ -66,7 +65,6 @@ describe('Integration: Component: gh-psm-template-select', function () {
         });
 
         await render(hbs`{{gh-psm-template-select post=post}}`);
-        await wait();
 
         expect(find('select').disabled, 'select is disabled').to.be.true;
         expect(find('p')).to.contain.text('post-one.hbs');
@@ -81,7 +79,6 @@ describe('Integration: Component: gh-psm-template-select', function () {
         });
 
         await render(hbs`{{gh-psm-template-select post=post}}`);
-        await wait();
 
         expect(find('select').disabled, 'select is disabled').to.be.true;
         expect(find('p')).to.contain.text('page-about.hbs');

--- a/tests/integration/components/gh-trim-focus-input-test.js
+++ b/tests/integration/components/gh-trim-focus-input-test.js
@@ -13,7 +13,7 @@ describe('Integration: Component: gh-trim-focus-input', function () {
 
         await blur('input');
 
-        expect(this.get('text')).to.equal('some random stuff');
+        expect(this.text).to.equal('some random stuff');
     });
 
     it('trims value on focusOut before calling custom focus-out', async function () {
@@ -31,7 +31,7 @@ describe('Integration: Component: gh-trim-focus-input', function () {
 
         await blur('input');
 
-        expect(this.get('text')).to.equal('some random stuff');
+        expect(this.text).to.equal('some random stuff');
     });
 
     it('does not have the autofocus attribute if not set to focus', async function () {

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -74,7 +74,7 @@ describe('Integration: Component: gh-uploader', function () {
             this.set('files', [createFile(), createFile()]);
             await settled();
 
-            expect(this.get('uploadStarted').calledOnce).to.be.true;
+            expect(this.uploadStarted.calledOnce).to.be.true;
         });
 
         it('triggers onUploadSuccess when a file uploads', async function () {
@@ -85,10 +85,10 @@ describe('Integration: Component: gh-uploader', function () {
             await settled();
 
             // triggered for each file
-            expect(this.get('fileUploaded').calledTwice).to.be.true;
+            expect(this.fileUploaded.calledTwice).to.be.true;
 
             // filename and url is passed in arg
-            let firstCall = this.get('fileUploaded').getCall(0);
+            let firstCall = this.fileUploaded.getCall(0);
             expect(firstCall.args[0].fileName).to.equal('file1.png');
             expect(firstCall.args[0].url).to.equal('/content/images/test.png');
         });
@@ -103,10 +103,10 @@ describe('Integration: Component: gh-uploader', function () {
             ]);
             await settled();
 
-            expect(this.get('uploadsFinished').calledOnce).to.be.true;
+            expect(this.uploadsFinished.calledOnce).to.be.true;
 
             // array of filenames and urls is passed in arg
-            let [result] = this.get('uploadsFinished').getCall(0).args;
+            let [result] = this.uploadsFinished.getCall(0).args;
             expect(result.length).to.equal(2);
             expect(result[0].fileName).to.equal('file1.png');
             expect(result[0].url).to.equal('/content/images/test.png');
@@ -129,7 +129,7 @@ describe('Integration: Component: gh-uploader', function () {
 
             await settled();
 
-            let [results] = this.get('uploadsFinished').getCall(1).args;
+            let [results] = this.uploadsFinished.getCall(1).args;
             expect(results.length).to.equal(1);
             expect(results[0].fileName).to.equal('file2.png');
         });
@@ -152,7 +152,7 @@ describe('Integration: Component: gh-uploader', function () {
             ]);
             await settled();
 
-            let [results] = this.get('uploadsFinished').getCall(0).args;
+            let [results] = this.uploadsFinished.getCall(0).args;
             expect(results.length).to.equal(2);
             expect(results[0].fileName).to.equal('file1.png');
         });
@@ -253,8 +253,8 @@ describe('Integration: Component: gh-uploader', function () {
             await waitFor('.cancel-button');
             await click('.cancel-button');
 
-            expect(this.get('cancelled').calledOnce, 'onCancel triggered').to.be.true;
-            expect(this.get('complete').notCalled, 'onComplete triggered').to.be.true;
+            expect(this.cancelled.calledOnce, 'onCancel triggered').to.be.true;
+            expect(this.complete.notCalled, 'onComplete triggered').to.be.true;
         });
 
         it('uploads to supplied `uploadUrl`', async function () {
@@ -293,7 +293,7 @@ describe('Integration: Component: gh-uploader', function () {
             this.set('files', [createFile(['test'], {name: 'test.png'})]);
             await settled();
 
-            let [onFailedResult] = this.get('onFailed').firstCall.args;
+            let [onFailedResult] = this.onFailed.firstCall.args;
             expect(onFailedResult.length).to.equal(1);
             expect(onFailedResult[0].fileName, 'onFailed file name').to.equal('test.png');
             expect(onFailedResult[0].message, 'onFailed message').to.match(/not supported/);
@@ -311,7 +311,7 @@ describe('Integration: Component: gh-uploader', function () {
             this.set('files', [createFile(['test'], {name: 'test.png'})]);
             await settled();
 
-            let [onFailedResult] = this.get('onFailed').firstCall.args;
+            let [onFailedResult] = this.onFailed.firstCall.args;
             expect(onFailedResult.length).to.equal(1);
             expect(onFailedResult[0].fileName).to.equal('test.png');
             expect(onFailedResult[0].message).to.equal('test.png failed test validation');
@@ -356,10 +356,10 @@ describe('Integration: Component: gh-uploader', function () {
             ]);
             await settled();
 
-            expect(this.get('uploadFailed').calledOnce).to.be.true;
-            expect(this.get('uploadComplete').calledOnce).to.be.true;
+            expect(this.uploadFailed.calledOnce).to.be.true;
+            expect(this.uploadComplete.calledOnce).to.be.true;
 
-            let [failures] = this.get('uploadFailed').firstCall.args;
+            let [failures] = this.uploadFailed.firstCall.args;
             expect(failures.length).to.equal(2);
             expect(failures[0].fileName).to.equal('file1.png');
             expect(failures[0].message).to.equal('Error: No upload for you');
@@ -380,13 +380,13 @@ describe('Integration: Component: gh-uploader', function () {
             ]);
             await settled();
 
-            expect(this.get('uploadFail').calledTwice).to.be.true;
+            expect(this.uploadFail.calledTwice).to.be.true;
 
-            let [firstFailure] = this.get('uploadFail').firstCall.args;
+            let [firstFailure] = this.uploadFail.firstCall.args;
             expect(firstFailure.fileName).to.equal('file1.png');
             expect(firstFailure.message).to.equal('Error: No upload for you');
 
-            let [secondFailure] = this.get('uploadFail').secondCall.args;
+            let [secondFailure] = this.uploadFail.secondCall.args;
             expect(secondFailure.fileName).to.equal('file2.png');
             expect(secondFailure.message).to.equal('Error: No upload for you');
         });

--- a/tests/integration/services/config-test.js
+++ b/tests/integration/services/config-test.js
@@ -1,8 +1,8 @@
 import Pretender from 'pretender';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
+import {settled} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
 
 describe('Integration: Service: config', function () {
@@ -63,7 +63,7 @@ describe('Integration: Service: config', function () {
             ).to.equal('http://localhost:2368');
         });
 
-        wait().then(() => {
+        settled().then(() => {
             stubBlogUrl('http://localhost:2368');
 
             service.fetch().then(() => {

--- a/tests/integration/services/feature-test.js
+++ b/tests/integration/services/feature-test.js
@@ -2,10 +2,10 @@ import EmberError from '@ember/error';
 import FeatureService, {feature} from 'ghost-admin/services/feature';
 import Pretender from 'pretender';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
+import {settled} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
 
 function stubSettings(server, labs, validSave = true) {
@@ -226,7 +226,7 @@ describe('Integration: Service: feature', function () {
                 service.set('testFlag', true);
             });
 
-            return wait().then(() => {
+            return settled().then(() => {
                 expect(server.handlers[1].numberOfCalls).to.equal(1);
                 expect(service.get('testFlag')).to.be.true;
             });
@@ -251,7 +251,7 @@ describe('Integration: Service: feature', function () {
                 service.set('testUserFlag', true);
             });
 
-            return wait().then(() => {
+            return settled().then(() => {
                 expect(server.handlers[3].numberOfCalls).to.equal(1);
                 expect(service.get('testUserFlag')).to.be.true;
             });
@@ -277,7 +277,7 @@ describe('Integration: Service: feature', function () {
                 service.set('testFlag', true);
             });
 
-            return wait().then(() => {
+            return settled().then(() => {
                 expect(
                     server.handlers[1].numberOfCalls,
                     'PUT call is made'
@@ -311,7 +311,7 @@ describe('Integration: Service: feature', function () {
                 service.set('testUserFlag', true);
             });
 
-            return wait().then(() => {
+            return settled().then(() => {
                 expect(
                     server.handlers[3].numberOfCalls,
                     'PUT call is made'
@@ -348,7 +348,7 @@ describe('Integration: Service: feature', function () {
                 }, EmberError, 'threw validation error');
             });
 
-            return wait().then(() => {
+            return settled().then(() => {
                 // ensure validation is happening before the API is hit
                 expect(server.handlers[1].numberOfCalls).to.equal(0);
                 expect(service.get('testFlag')).to.be.false;

--- a/tests/unit/controllers/editor-test.js
+++ b/tests/unit/controllers/editor-test.js
@@ -26,7 +26,7 @@ describe('Unit: Controller: editor', function () {
 
             expect(controller.get('post.slug')).to.equal('');
 
-            await controller.get('generateSlugTask').perform();
+            await controller.generateSlugTask.perform();
 
             expect(controller.get('post.slug')).to.equal('title-slug');
         });
@@ -44,7 +44,7 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.slug')).to.equal('whatever');
 
             controller.set('post.titleScratch', '(Untitled)');
-            await controller.get('generateSlugTask').perform();
+            await controller.generateSlugTask.perform();
 
             expect(controller.get('post.slug')).to.equal('whatever');
         });
@@ -70,7 +70,7 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
-            await controller.get('saveTitleTask').perform();
+            await controller.saveTitleTask.perform();
 
             expect(controller.get('post.titleScratch')).to.equal('test');
             expect(controller.get('post.slug')).to.equal('test-slug');
@@ -91,7 +91,7 @@ describe('Unit: Controller: editor', function () {
 
             controller.set('post.titleScratch', 'New Title');
 
-            await controller.get('saveTitleTask').perform();
+            await controller.saveTitleTask.perform();
 
             expect(controller.get('post.titleScratch')).to.equal('New Title');
             expect(controller.get('post.slug')).to.equal('test-slug');
@@ -115,7 +115,7 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
-            await controller.get('saveTitleTask').perform();
+            await controller.saveTitleTask.perform();
 
             expect(controller.get('post.titleScratch')).to.equal('test');
             expect(controller.get('post.slug')).to.not.be.ok;
@@ -135,7 +135,7 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.title')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'title');
-            await controller.get('saveTitleTask').perform();
+            await controller.saveTitleTask.perform();
 
             expect(controller.get('post.titleScratch')).to.equal('title');
             expect(controller.get('post.slug')).to.not.be.ok;

--- a/tests/unit/models/invite-test.js
+++ b/tests/unit/models/invite-test.js
@@ -1,9 +1,9 @@
 import Pretender from 'pretender';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
+import {settled} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Model: invite', function () {
@@ -41,7 +41,7 @@ describe('Unit: Model: invite', function () {
                 model.set('role', role);
                 model.resend();
             });
-            await wait();
+            await settled();
 
             expect(
                 server.handledRequests.length,

--- a/tests/unit/services/unsplash-test.js
+++ b/tests/unit/services/unsplash-test.js
@@ -1,8 +1,8 @@
 import Pretender from 'pretender';
-import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
+import {settled} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Service: unsplash', function () {
@@ -45,7 +45,7 @@ describe('Unit: Service: unsplash', function () {
             run(() => {
                 service.loadNextPage();
             });
-            await wait();
+            await settled();
 
             expect(service.get('error')).to.have.string('Unsplash API rate limit reached');
         });
@@ -62,7 +62,7 @@ describe('Unit: Service: unsplash', function () {
             run(() => {
                 service.loadNextPage();
             });
-            await wait();
+            await settled();
 
             expect(service.get('error')).to.equal('Unsplash API Error');
         });
@@ -77,7 +77,7 @@ describe('Unit: Service: unsplash', function () {
             run(() => {
                 service.loadNextPage();
             });
-            await wait();
+            await settled();
 
             expect(service.get('error')).to.equal('Unsplash text error');
         });


### PR DESCRIPTION
no issue

Part of Ember upgrades.

- removed all unnecessary usage of `.get`
- cleaned up imports where we had imports from the same module across multiple lines
- standardized on importing specific computed helpers rather than using `computed.foo`
- switched tests from using `wait()` to `settled()`