### PR TITLE
Updated specific tier visibility handling for posts/pages

### DIFF
--- a/app/components/gh-post-settings-menu.hbs
+++ b/app/components/gh-post-settings-menu.hbs
@@ -80,17 +80,15 @@
                             <GhPsmVisibilityInput @post={{this.post}} @triggerId="visibility-input" />
                         </GhFormGroup>
 
-                        {{#if (eq this.post.visibility "filter")}}
-                            <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="visibilityFilter" @class="nt3">
-                                <GhMembersSegmentSelect
-                                    @hideLabels={{true}}
+                        {{#if (eq this.post.visibility "tiers")}}
+                            <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="tiers" @class="nt3">
+                                <GhPostSettingsMenu::VisibilitySegmentSelect
                                     @segment={{this.post.visibilitySegment}}
                                     @onChange={{action "setVisibility"}}
                                     @renderInPlace={{true}}
-                                    @hideDefaultSegments={{true}}
                                     @hideOptionsWhenAllSelected={{true}}
                                 />
-                                <GhErrorMessage @errors={{this.post.errors}} @property="visibilityFilter" data-test-error="visibilityFilter" />
+                                <GhErrorMessage @errors={{this.post.errors}} @property="tiers" data-test-error="tiers" />
                             </GhFormGroup>
                         {{/if}}
                     {{else}}

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -143,11 +143,11 @@ export default Component.extend({
         },
 
         async setVisibility(segment) {
-            this.post.set('visibilityFilter', segment);
+            this.post.set('tiers', segment);
             try {
                 await this.post.validate({property: 'visibility'});
-                await this.post.validate({property: 'visibilityFilter'});
-                if (this.post.get('isDraft') && this.post.changedAttributes().visibilityFilter) {
+                await this.post.validate({property: 'tiers'});
+                if (this.post.get('isDraft') && this.post.changedAttributes().tiers) {
                     await this.savePostTask.perform();
                 }
             } catch (e) {

--- a/app/components/gh-post-settings-menu/visibility-segment-select.hbs
+++ b/app/components/gh-post-settings-menu/visibility-segment-select.hbs
@@ -1,0 +1,21 @@
+<GhTokenInput
+    @options={{this.options}}
+    @selected={{this.selectedOptions}}
+    @disabled={{or @disabled this.fetchOptionsTask.isRunning}}
+    @optionsComponent="power-select/options"
+    @allowCreation={{false}}
+    @renderInPlace={{this.renderInPlace}}
+    @onChange={{this.setSegment}}
+    @disabled={{@disabled}}
+    @class="select-members"
+    @placeholder="Select a tier"
+    as |option|
+>
+    {{option.name}}
+</GhTokenInput>
+
+<GhMembersSegmentCount
+    @segment={{@segment}}
+    @enforcedFilter={{@enforcedCountFilter}}
+    @onSegmentCountChange={{@onSegmentCountChange}}
+/>

--- a/app/components/gh-post-settings-menu/visibility-segment-select.js
+++ b/app/components/gh-post-settings-menu/visibility-segment-select.js
@@ -1,0 +1,106 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency-decorators';
+import {tracked} from '@glimmer/tracking';
+
+export default class VisibilitySegmentSelect extends Component {
+    @service store;
+    @service feature;
+
+    @tracked _options = [];
+    @tracked products = [];
+
+    get renderInPlace() {
+        return this.args.renderInPlace === undefined ? false : this.args.renderInPlace;
+    }
+
+    constructor() {
+        super(...arguments);
+        this.fetchOptionsTask.perform();
+    }
+
+    get options() {
+        if (this.args.hideOptionsWhenAllSelected) {
+            const selectedSegments = this.selectedOptions.mapBy('segment');
+            if (selectedSegments.includes('status:free') && selectedSegments.includes('status:-free')) {
+                return this._options.filter(option => !option.groupName);
+            }
+        }
+
+        return this._options;
+    }
+
+    get flatOptions() {
+        const options = [];
+
+        function getOptions(option) {
+            if (option.options) {
+                return option.options.forEach(getOptions);
+            }
+
+            options.push(option);
+        }
+
+        this._options.forEach(getOptions);
+
+        return options;
+    }
+
+    get selectedOptions() {
+        const segments = (this.args.segment || '').split(',');
+        return this.flatOptions.filter(option => segments.includes(option.segment));
+    }
+
+    @action
+    setSegment(options) {
+        const segment = options.mapBy('segment').join(',') || null;
+        let ids = segment?.split(',').map((d) => {
+            let slug = d.replace('product:', '');
+            let product = this.products.find((p) => {
+                return p.slug === slug;
+            });
+            return {
+                id: product.id,
+                slug: product.slug,
+                name: product.name
+            };
+        }) || [];
+        this.args.onChange?.(ids);
+    }
+
+    @task
+    *fetchOptionsTask() {
+        const options = yield [];
+
+        if (this.feature.get('multipleProducts')) {
+            // fetch all products with count
+            // TODO: add `include: 'count.members` to query once API supports
+            const products = yield this.store.query('product', {filter: 'type:paid', limit: 'all', include: 'monthly_price,yearly_price,benefits'});
+            this.products = products;
+
+            if (products.length > 0) {
+                const productsGroup = {
+                    groupName: 'Tiers',
+                    options: []
+                };
+
+                products.forEach((product) => {
+                    productsGroup.options.push({
+                        name: product.name,
+                        segment: `product:${product.slug}`,
+                        count: product.count?.members,
+                        class: 'segment-product'
+                    });
+                });
+
+                options.push(productsGroup);
+                if (this.args.selectDefaultProduct && !this.args.segment) {
+                    this.args.onChange?.(productsGroup.options[0].segment);
+                }
+            }
+        }
+
+        this._options = options;
+    }
+}

--- a/app/components/gh-psm-visibility-input.js
+++ b/app/components/gh-psm-visibility-input.js
@@ -25,7 +25,7 @@ export default Component.extend({
         this.availableVisibilities = [...VISIBILITIES];
         if (this.feature.get('multipleProducts')) {
             this.availableVisibilities.push(
-                {label: 'Specific tier(s)', name: 'filter'}
+                {label: 'Specific tier(s)', name: 'tiers'}
             );
         }
     },
@@ -33,8 +33,8 @@ export default Component.extend({
     actions: {
         updateVisibility(newVisibility) {
             this.post.set('visibility', newVisibility);
-            if (newVisibility !== 'filter') {
-                this.post.set('visibilityFilter', null);
+            if (newVisibility !== 'tiers') {
+                this.post.set('tiers', []);
             }
         }
     }

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -179,8 +179,8 @@ export default Component.extend({
                 return 'status:-free';
             }
 
-            if (this.post.visibility === 'filter') {
-                return this.post.visibilityFilter;
+            if (this.post.visibility === 'tiers') {
+                return this.post.visibilitySegment;
             }
 
             return this.post.visibility;

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -644,7 +644,6 @@ export default Controller.extend({
             yield post.save(options);
         } catch (error) {
             this.post.set('emailOnly', previousEmailOnlyValue);
-
             if (isServerUnreachableError(error)) {
                 const [prevStatus, newStatus] = this.post.changedAttributes().status || [this.post.status, this.post.status];
                 this._showErrorAlert(prevStatus, newStatus, error);

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -92,7 +92,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     emailSubject: attr('string'),
     html: attr('string'),
     visibility: attr('string'),
-    visibilityFilter: attr('string'),
     metaDescription: attr('string'),
     metaTitle: attr('string'),
     mobiledoc: attr('json-string', {defaultValue: () => JSON.parse(JSON.stringify(BLANK_DOC))}),
@@ -145,7 +144,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     ogTitleScratch: boundOneWay('ogTitle'),
     twitterDescriptionScratch: boundOneWay('twitterDescription'),
     twitterTitleScratch: boundOneWay('twitterTitle'),
-
+    tiers: attr('member-product'),
     emailSubjectScratch: boundOneWay('emailSubject'),
 
     isPublished: equal('status', 'published'),
@@ -180,7 +179,7 @@ export default Model.extend(Comparable, ValidationEngine, {
         return this.visibility === 'public' ? true : false;
     }),
 
-    visibilitySegment: computed('visibility', 'visibilityFilter', 'isPublic', function () {
+    visibilitySegment: computed('visibility', 'isPublic', 'tiers', function () {
         if (this.isPublic) {
             return this.settings.get('defaultContentVisibility') === 'paid' ? 'status:-free' : 'status:free,status:-free';
         } else {
@@ -190,8 +189,11 @@ export default Model.extend(Comparable, ValidationEngine, {
             if (this.visibility === 'paid') {
                 return 'status:-free';
             }
-            if (this.visibility === 'filter') {
-                return this.visibilityFilter;
+            if (this.visibility === 'tiers' && this.tiers) {
+                let filter = this.tiers.map((tier) => {
+                    return `product:${tier.slug}`;
+                }).join(',');
+                return filter;
             }
             return this.visibility;
         }

--- a/app/serializers/page.js
+++ b/app/serializers/page.js
@@ -12,6 +12,21 @@ export default PostSerializer.extend({
         delete json.email_id;
         delete json.email;
 
+        if (json.visibility === null) {
+            delete json.visibility;
+            delete json.visibility_filter;
+            delete json.tiers;
+        }
+
+        if (json.visibility === 'tiers') {
+            delete json.visibility_filter;
+        }
+
+        if (json.visibility === 'tiers' && !json.tiers?.length) {
+            delete json.visibility;
+            delete json.tiers;
+        }
+
         return json;
     }
 });

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -46,11 +46,16 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
         if (json.visibility === null) {
             delete json.visibility;
             delete json.visibility_filter;
+            delete json.tiers;
         }
 
-        if (json.visibility === 'filter' && json.visibility_filter === null) {
-            delete json.visibility;
+        if (json.visibility === 'tiers') {
             delete json.visibility_filter;
+        }
+
+        if (json.visibility === 'tiers' && !json.tiers?.length) {
+            delete json.visibility;
+            delete json.tiers;
         }
 
         return json;

--- a/app/validators/post.js
+++ b/app/validators/post.js
@@ -74,9 +74,9 @@ export default BaseValidator.create({
         }
     },
 
-    visibilityFilter(model) {
-        if (isBlank(model.visibilityFilter) && !isBlank(model.visibility) && model.visibility === 'filter' && !model.isNew) {
-            model.errors.add('visibilityFilter', 'Please select at least one tier');
+    tiers(model) {
+        if (model.visibility === 'tiers' && !model.isNew && isEmpty(model.tiers)) {
+            model.errors.add('tiers', 'Please select at least one tier');
             this.invalidate();
         }
     },

--- a/tests/integration/components/gh-psm-visibility-input-test.js
+++ b/tests/integration/components/gh-psm-visibility-input-test.js
@@ -39,6 +39,6 @@ describe('Integration: Component: gh-psm-visibility-input', function () {
 
         expect(setVisibility.calledTwice).to.be.true;
         expect(setVisibility.calledWith('visibility', 'paid')).to.be.true;
-        expect(setVisibility.calledWith('visibilityFilter', null)).to.be.true;
+        expect(setVisibility.calledWith('tiers', [])).to.be.true;
     });
 });


### PR DESCRIPTION
refs TryGhost/Team#1071

Specific tier visibility for a post was previously stored in `visibility` column directly, which had a limitation of 50 charts. Going forward, for the specific tiers visibility of post/page, we use `tiers` array in API that contains list of tiers with access for post. This change -

- replaces `filter` type to `tiers` for visibility
- adds new visibility filter segment component in post settings menu which stores array of tiers instead of nql string for visibility
- updates serializer and model for post/page
- updates tests
