### PR TITLE
[chore] runs native classes codemod for apps/helpers

### DIFF
--- a/app/helpers/gravatar.js
+++ b/app/helpers/gravatar.js
@@ -1,10 +1,13 @@
 import Helper from '@ember/component/helper';
+import classic from 'ember-classic-decorator';
 import md5 from 'blueimp-md5';
 import {isEmpty} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
-export default Helper.extend({
-    config: service(),
+@classic
+export default class Gravatar extends Helper {
+    @service
+    config;
 
     compute([email], {size = 180, d = 'blank'}/*, hash*/) {
         if (!this.get('config.useGravatar')) {
@@ -17,4 +20,4 @@ export default Helper.extend({
 
         return `https://www.gravatar.com/avatar/${md5(email)}?s=${size}&d=${d}`;
     }
-});
+}

--- a/app/helpers/members-event-filter.js
+++ b/app/helpers/members-event-filter.js
@@ -1,14 +1,20 @@
 import Helper from '@ember/component/helper';
+import classic from 'ember-classic-decorator';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
 export const EMAIL_EVENTS = ['email_delivered_event','email_opened_event','email_failed_event'];
 export const NEWSLETTER_EVENTS = ['newsletter_event'];
 
-export default Helper.extend({
-    settings: service(),
+@classic
+export default class MembersEventFilter extends Helper {
+    @service
+    settings;
 
-    compute(positionalParams, {excludedEvents = [], member = '', excludeEmailEvents = false}) {
+    compute(
+        positionalParams,
+        {excludedEvents = [], member = '', excludeEmailEvents = false}
+    ) {
         const excludedEventsSet = new Set();
 
         if (this.settings.get('editorDefaultEmailRecipients') === 'disabled') {
@@ -36,4 +42,4 @@ export default Helper.extend({
 
         return filterParts.join('+');
     }
-});
+}


### PR DESCRIPTION
A continuation of #2227 that runs the native classes codemod against app/helpers.

This one was really easy, all the of the helpers are already converted!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
