### PR TITLE
[chore] runs native classes codemod for apps/serializers

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,27 +1,29 @@
+import classic from 'ember-classic-decorator';
 import RESTSerializer from '@ember-data/serializer/rest';
 import {camelize, decamelize, underscore} from '@ember/string';
 import {pluralize} from 'ember-inflector';
 
-export default RESTSerializer.extend({
+@classic
+export default class Application extends RESTSerializer {
     // hacky method for getting access to meta data for single-resource responses
     // https://github.com/emberjs/data/pull/4077#issuecomment-200780097
     // TODO: review once the record links and meta RFC lands
     // https://github.com/emberjs/rfcs/blob/master/text/0332-ember-data-record-links-and-meta.md
     extractMeta(store, typeClass) {
-        let meta = this._super(...arguments);
+        let meta = super.extractMeta(...arguments);
         typeClass.___meta = meta;
         return meta;
-    },
+    }
 
-    serialize(/*snapshot, options*/) {
-        let json = this._super(...arguments);
+    serialize/*snapshot, options*/() {
+        let json = super.serialize/*snapshot, options*/(...arguments);
 
         // don't send attributes that are updated automatically on the server
         delete json.created_by;
         delete json.updated_by;
 
         return json;
-    },
+    }
 
     serializeIntoHash(hash, type, record, options) {
         // Our API expects an id on the posted object
@@ -33,11 +35,11 @@ export default RESTSerializer.extend({
         let data = this.serialize(record, options);
 
         hash[root] = [data];
-    },
+    }
 
     keyForAttribute(attr) {
         return decamelize(attr);
-    },
+    }
 
     keyForRelationship(key, typeClass, method) {
         let transform = method === 'serialize' ? underscore : camelize;
@@ -49,4 +51,4 @@ export default RESTSerializer.extend({
 
         return transform(key);
     }
-});
+}

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,5 +1,5 @@
-import classic from 'ember-classic-decorator';
 import RESTSerializer from '@ember-data/serializer/rest';
+import classic from 'ember-classic-decorator';
 import {camelize, decamelize, underscore} from '@ember/string';
 import {pluralize} from 'ember-inflector';
 

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -15,8 +15,8 @@ export default class Application extends RESTSerializer {
         return meta;
     }
 
-    serialize/*snapshot, options*/() {
-        let json = super.serialize/*snapshot, options*/(...arguments);
+    serialize() {
+        let json = super.serialize(...arguments);
 
         // don't send attributes that are updated automatically on the server
         delete json.created_by;

--- a/app/serializers/page.js
+++ b/app/serializers/page.js
@@ -1,8 +1,10 @@
+import classic from 'ember-classic-decorator';
 import PostSerializer from './post';
 
-export default PostSerializer.extend({
-    serialize(/*snapshot, options*/) {
-        let json = this._super(...arguments);
+@classic
+export default class Page extends PostSerializer {
+    serialize/*snapshot, options*/() {
+        let json = super.serialize/*snapshot, options*/(...arguments);
 
         // Properties that exist on the model but we don't want sent in the payload
         delete json.email_subject;
@@ -29,4 +31,4 @@ export default PostSerializer.extend({
 
         return json;
     }
-});
+}

--- a/app/serializers/page.js
+++ b/app/serializers/page.js
@@ -3,8 +3,8 @@ import classic from 'ember-classic-decorator';
 
 @classic
 export default class Page extends PostSerializer {
-    serialize/*snapshot, options*/() {
-        let json = super.serialize/*snapshot, options*/(...arguments);
+    serialize() {
+        let json = super.serialize(...arguments);
 
         // Properties that exist on the model but we don't want sent in the payload
         delete json.email_subject;

--- a/app/serializers/page.js
+++ b/app/serializers/page.js
@@ -1,5 +1,5 @@
-import classic from 'ember-classic-decorator';
 import PostSerializer from './post';
+import classic from 'ember-classic-decorator';
 
 @classic
 export default class Page extends PostSerializer {

--- a/app/serializers/setting.js
+++ b/app/serializers/setting.js
@@ -1,7 +1,9 @@
+import classic from 'ember-classic-decorator';
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 import {pluralize} from 'ember-inflector';
 
-export default ApplicationSerializer.extend({
+@classic
+export default class Setting extends ApplicationSerializer {
     serializeIntoHash(hash, type, record, options) {
         // Settings API does not want ids
         options = options || {};
@@ -18,17 +20,17 @@ export default ApplicationSerializer.extend({
         });
 
         hash[root] = payload;
-    },
+    }
 
     normalizeArrayResponse(store, primaryModelClass, _payload, id, requestType) {
         let payload = {settings: [this._extractObjectFromArrayPayload(_payload)]};
-        return this._super(store, primaryModelClass, payload, id, requestType);
-    },
+        return super.normalizeArrayResponse(store, primaryModelClass, payload, id, requestType);
+    }
 
     normalizeSingleResponse(store, primaryModelClass, _payload, id, requestType) {
         let payload = {setting: this._extractObjectFromArrayPayload(_payload)};
-        return this._super(store, primaryModelClass, payload, id, requestType);
-    },
+        return super.normalizeSingleResponse(store, primaryModelClass, payload, id, requestType);
+    }
 
     _extractObjectFromArrayPayload(_payload) {
         let payload = {id: '0'};
@@ -39,4 +41,4 @@ export default ApplicationSerializer.extend({
 
         return payload;
     }
-});
+}

--- a/app/serializers/setting.js
+++ b/app/serializers/setting.js
@@ -1,5 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationSerializer from 'ghost-admin/serializers/application';
+import classic from 'ember-classic-decorator';
 import {pluralize} from 'ember-inflector';
 
 @classic

--- a/app/serializers/theme.js
+++ b/app/serializers/theme.js
@@ -1,5 +1,7 @@
+import classic from 'ember-classic-decorator';
 import ApplicationSerializer from './application';
 
-export default ApplicationSerializer.extend({
-    primaryKey: 'name'
-});
+@classic
+export default class Theme extends ApplicationSerializer {
+    primaryKey = 'name';
+}

--- a/app/serializers/theme.js
+++ b/app/serializers/theme.js
@@ -1,5 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationSerializer from './application';
+import classic from 'ember-classic-decorator';
 
 @classic
 export default class Theme extends ApplicationSerializer {


### PR DESCRIPTION
A continuation of #2227 that runs the native classes codemod against app/serializers.

Most of the serializers that are trying to be transformed are failing with the same issue:

```
Validation errors: 
	[attrs]: Transform not supported - value is of type object. For more details: eslint-plugin-ember/avoid-leaking-state-in-ember-objects
2022-02-02T05:54:58.571Z [warn] [app/serializers/role.js]: FAILURE 
```

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
