### PR TITLE
🐛 Fixed bug where the slug of a tag wasn't shown on the tag list view

### DIFF
--- a/app/components/gh-tag-settings-form.hbs
+++ b/app/components/gh-tag-settings-form.hbs
@@ -103,7 +103,7 @@
                 <h4 class="gh-expandable-title">Meta data</h4>
                 <p class="gh-expandable-description">Extra content for search engines.</p>
             </div>
-            <button type="button" class="gh-btn gh-btn-expand" {{action (toggle "metadataOpen" this)}}><span>{{if this.metadataOpen "Close" "Expand"}}</span></button>
+            <button type="button" name="meta" class="gh-btn gh-btn-expand" {{action (toggle "metadataOpen" this)}}><span>{{if this.metadataOpen "Close" "Expand"}}</span></button>
         </div>
 
         <div class="gh-expandable-content">
@@ -177,7 +177,7 @@
                 <h4 class="gh-expandable-title">Twitter card</h4>
                 <p class="gh-expandable-description">Customized structured data for Twitter.</p>
             </div>
-            <button type="button" class="gh-btn gh-btn-expand" {{action (toggle "twitterMetadataOpen" this)}}><span>{{if this.twitterMetadataOpen "Close" "Expand"}}</span></button>
+            <button type="button" name="twitter" class="gh-btn gh-btn-expand" {{action (toggle "twitterMetadataOpen" this)}}><span>{{if this.twitterMetadataOpen "Close" "Expand"}}</span></button>
         </div>
 
         <div class="gh-expandable-content">
@@ -271,7 +271,7 @@
                 <h4 class="gh-expandable-title">Facebook card</h4>
                 <p class="gh-expandable-description">Customize Open Graph data.</p>
             </div>
-            <button type="button" class="gh-btn gh-btn-expand" {{action (toggle "facebookMetadataOpen" this)}}><span>{{if this.facebookMetadataOpen "Close" "Expand"}}</span></button>
+            <button type="button" name="facebook" class="gh-btn gh-btn-expand" {{action (toggle "facebookMetadataOpen" this)}}><span>{{if this.facebookMetadataOpen "Close" "Expand"}}</span></button>
         </div>
 
         <div class="gh-expandable-content">
@@ -366,7 +366,7 @@
                 <h4 class="gh-expandable-title">Code injection</h4>
                 <p class="gh-expandable-description">Add styles/scripts to the header and footer.</p>
             </div>
-            <button type="button" class="gh-btn gh-btn-expand" {{action (toggle "codeInjectionOpen" this)}}><span>{{if this.codeInjectionOpen "Close" "Expand"}}</span></button>
+            <button type="button" name="code-injection" class="gh-btn gh-btn-expand" {{action (toggle "codeInjectionOpen" this)}}><span>{{if this.codeInjectionOpen "Close" "Expand"}}</span></button>
         </div>
 
         <div class="gh-expandable-content">

--- a/app/components/gh-tags-list-item.hbs
+++ b/app/components/gh-tags-list-item.hbs
@@ -11,7 +11,7 @@
     </LinkTo>
 
     <LinkTo @route="tag" @model={{@tag}} class="gh-list-data middarkgrey f8 gh-tag-list-slug gh-list-cellwidth-10" title="Edit tag">
-        <span title="{{@slug}}">{{@slug}}</span>
+        <span title="{{@tag.slug}}">{{@tag.slug}}</span>
     </LinkTo>
 
     {{#if @tag.count.posts}}

--- a/app/components/gh-tags-list-item.hbs
+++ b/app/components/gh-tags-list-item.hbs
@@ -1,8 +1,6 @@
 <li class="gh-list-row gh-tags-list-item" ...attributes>
     <LinkTo @route="tag" @model={{@tag}} class="gh-list-data gh-tag-list-title gh-list-cellwidth-70" title="Edit tag">
-        <h3 class="gh-tag-list-name">
-            {{@tag.name}}
-        </h3>
+        <h3 class="gh-tag-list-name">{{@tag.name}}</h3>
         {{#if @tag.description}}
             <p class="ma0 pa0 f8 midgrey gh-tag-list-description">
                 {{@tag.description}}

--- a/app/components/modal-delete-tag.hbs
+++ b/app/components/modal-delete-tag.hbs
@@ -12,5 +12,5 @@
 
 <div class="modal-footer">
     <button class="gh-btn" type="button" {{action "closeModal"}}><span>Cancel</span></button>
-    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deleteTag}} @class="gh-btn gh-btn-red gh-btn-icon" />
+    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deleteTag}} @class="gh-btn gh-btn-red gh-btn-icon" data-test-modal-confirm />
 </div>

--- a/app/controllers/tags.js
+++ b/app/controllers/tags.js
@@ -24,7 +24,8 @@ export default class TagsController extends Controller {
     // tags are sorted by name
     @sort('filteredTags', function (tagA, tagB) {
         // ignorePunctuation means the # in internal tag names is ignored
-        return tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true});
+        // numeric and sensitivity ensure that tags starting with 11 are sorted after tags 1-9
+        return tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true, numeric: true, sensitivity: 'base'});
     })
         sortedTags;
 

--- a/app/templates/tag.hbs
+++ b/app/templates/tag.hbs
@@ -19,7 +19,7 @@
 
     {{#unless this.tag.isNew}}
         <div>
-            <button type="button" class="gh-btn gh-btn-red gh-btn-icon" {{on "click" (action "openDeleteTagModal")}}>
+            <button type="button" class="gh-btn gh-btn-red gh-btn-icon" {{on "click" (action "openDeleteTagModal")}} data-test-delete-button>
                 <span>Delete tag</span>
             </button>
         </div>

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -6,7 +6,7 @@
                 <button class="gh-btn {{if (eq this.type "public") "gh-btn-group-selected"}}" type="button" {{action "changeType" "public"}}><span>Public tags</span></button>
                 <button class="gh-btn {{if (eq this.type "internal") "gh-btn-group-selected"}}" type="button" {{action "changeType" "internal"}}><span>Internal tags</span></button>
             </div>
-            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary"><span>New tag</span></LinkTo>
+            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary" data-test-new-tag-button><span>New tag</span></LinkTo>
         </section>
     </GhCanvasHeader>
 
@@ -25,11 +25,11 @@
             {{else}}
                 <li class="no-posts-box">
                     <div class="no-posts">
-                            {{svg-jar "tags-placeholder" class="gh-tags-placeholder"}}
-                            <h4>Start organizing your content.</h4>
-                            <LinkTo @route="tag.new" class="gh-btn gh-btn-green">
-                                <span>Create a new tag</span>
-                            </LinkTo>
+                        {{svg-jar "tags-placeholder" class="gh-tags-placeholder"}}
+                        <h4>Start organizing your content.</h4>
+                        <LinkTo @route="tag.new" class="gh-btn gh-btn-green">
+                            <span>Create a new tag</span>
+                        </LinkTo>
                     </div>
                 </li>
             {{/if}}

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -113,7 +113,7 @@ describe.skip('Acceptance: Tags', function () {
             let tag = find('.tags-list .gh-tags-list-item');
             expect(tag.querySelector('.gh-tag-list-name').textContent, 'tag list item title')
                 .to.equal(tag1.name);
-            expect(tag.querySelector('.gh-tag-list-slug span[title="' + tag1.title + '"]').textContent, 'tag list item tag')
+            expect(tag.querySelector('.gh-tag-list-slug span').textContent, 'tag list item tag')
                 .to.equal(tag1.slug);
 
             // it highlights selected tag

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -113,6 +113,8 @@ describe.skip('Acceptance: Tags', function () {
             let tag = find('.tags-list .gh-tags-list-item');
             expect(tag.querySelector('.gh-tag-list-name').textContent, 'tag list item title')
                 .to.equal(tag1.name);
+            expect(tag.querySelector('.gh-tag-list-slug span[title="' + tag1.title + '"]').textContent, 'tag list item tag')
+                .to.equal(tag1.slug);
 
             // it highlights selected tag
             // expect(find(`a[href="/ghost/tags/${tag1.slug}"]`), 'highlights selected tag')


### PR DESCRIPTION
This will solve an issue where the tag slugs aren't shown on the tag list view.

For example, in the screenshot below you'll see that none of the slug fields are filled; 
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/2735602/154154464-9f68ed7c-a7b6-4fbf-b654-4c3d5f46fec6.png">

I did modify the test regarding the tags, however, as the complete test is being skipped I experienced that the test in a whole is outdated. I am willing to rewrite the whole test later this week to make it actually represent the current state of the tag section in the admin panel. 

Tests:
- [x] Rewrite skipped acceptance test
- [ ] Rewrite skipped integration test