### PR TITLE
Onboarding refinements

### DIFF
--- a/app/controllers/setup/finishing-touches.js
+++ b/app/controllers/setup/finishing-touches.js
@@ -1,12 +1,67 @@
 import Controller from '@ember/controller';
+import {isEmpty} from '@ember/utils';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
+
+const THEME_PROPERTIES = {
+    casper: ['description', 'color', 'coverImage'],
+    edition: ['description', 'color', 'coverImage'],
+    dawn: ['description', 'color', 'icon'],
+    dope: ['description', 'color', 'logo'],
+    bulletin: ['description', 'color', 'logo'],
+    alto: ['description', 'color', 'logo'],
+    journal: ['description', 'color', 'logo'],
+    wave: ['description', 'color', 'logo', 'coverImage'],
+    edge: ['description', 'color', 'logo'],
+    ease: ['description', 'color', 'logo', 'coverImage'],
+    ruby: ['description', 'color', 'logo', 'coverImage'],
+    london: ['description', 'color', 'logo'],
+    digest: ['description', 'color', 'logo']
+};
 
 export default class SetupFinishingTouchesController extends Controller {
     @service modals;
     @service router;
     @service settings;
+    @service store;
     @service themeManagement;
+
+    @tracked descriptionVisible;
+    @tracked colorVisible;
+    @tracked logoVisible;
+    @tracked iconVisible;
+    @tracked coverImageVisible;
+
+    themes = null;
+
+    // Default properties to display
+    themeProperties = ['description', 'color', 'coverImage'];
+
+    constructor() {
+        super(...arguments);
+        this.initThemeProperties.perform();
+    }
+
+    @task({drop: true})
+    *initThemeProperties() {
+        this.themes = yield this.store.peekAll('theme');
+        if (isEmpty(this.themes)) {
+            this.themes = yield this.store.findAll('theme');
+        }
+
+        const activeTheme = this.themes.findBy('active', true);
+
+        if (activeTheme && THEME_PROPERTIES[activeTheme.name]) {
+            this.themeProperties = THEME_PROPERTIES[activeTheme.name];
+        }
+
+        this.descriptionVisible = this.themeProperties.includes('description');
+        this.logoVisible = this.themeProperties.includes('logo');
+        this.iconVisible = this.themeProperties.includes('icon');
+        this.colorVisible = this.themeProperties.includes('color');
+        this.coverImageVisible = this.themeProperties.includes('coverImage');
+    }
 
     @task
     *saveAndContinueTask() {

--- a/app/controllers/setup/finishing-touches.js
+++ b/app/controllers/setup/finishing-touches.js
@@ -66,7 +66,6 @@ export default class SetupFinishingTouchesController extends Controller {
     @task
     *saveAndContinueTask() {
         yield this.settings.save();
-        this.modals.open('modals/get-started');
         this.router.transitionTo('home');
     }
 }

--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -1815,12 +1815,13 @@ section.gh-ds h2 {
 }
 
 .gh-finishing-touches header {
-    padding: 32px 0 24px;
+    padding: 0 0 24px;
+    margin-top: -4px;
 }
 
 .gh-finishing-touches header h1 {
-    font-size: 4.1rem;
-    letter-spacing: -0.025em;
+    font-size: 3.1rem;
+    letter-spacing: -0.015em;
     color: var(--black);
     margin: 0;
 }
@@ -1835,10 +1836,9 @@ section.gh-ds h2 {
 .gh-finishing-touches main {
     background: var(--white);
     box-shadow: 0 0 30px rgb(0 0 0 / 4%);
-    width: calc(100% - 32px);
-    height: calc(100% - 179px);
-    border-radius: 8px;
-    margin: 0 16px 16px;
+    width: 100%;
+    height: 100%;
+    margin: 0;
     animation: fadeUp ease 300ms;
     animation-iteration-count: 1;
     animation-fill-mode: forwards;
@@ -1861,18 +1861,24 @@ section.gh-ds h2 {
     margin-bottom: 12px;
 }
 
+.gh-finishing-touches-preview {
+    flex-grow: 1;
+    padding: 10vmin;
+    background: var(--whitegrey-l2);
+}
+
 .gh-finishing-touches .gh-browserpreview-previewcontainer {
-    box-shadow: 0 8px 30px rgb(0 0 0 / 8%);
     border-radius: 5px !important;
     overflow: hidden;
 }
 
-.gh-finishing-touches .gh-browserpreview-browser .tabs {
-    background: var(--white);
-}
-
 .gh-finishing-touches .gh-browserpreview-browser .tabs div {
     display: none;
+}
+
+.gh-finishing-touches .gh-stack-item .gh-btn {
+    background: var(--whitegrey);
+    box-shadow: none;
 }
 
 .gh-finishing-touches .gh-finishing-touches-button {
@@ -1881,9 +1887,12 @@ section.gh-ds h2 {
     z-index: 9999;
     display: flex;
     align-items: center;
-    height: 96px;
-    margin-bottom: -24px;
     background: var(--white);
+    padding: 32px;
+}
+
+.gh-finishing-touches .gh-nav {
+    flex: 0 0 420px !important;
 }
 
 

--- a/app/templates/setup/finishing-touches.hbs
+++ b/app/templates/setup/finishing-touches.hbs
@@ -1,15 +1,14 @@
 <div class="gh-flow gh-finishing-touches">
-    <header class="tc">
-        <h1>Finishing touches</h1>
-        <p>You chose a theme, now it's time to make it your own.</p>
-    </header>
     <main class="flex flex-row h-100">
-        {{!-- {{this.activeTheme.name}} --}}
         <div class="gh-nav gh-nav-contextual gh-nav-design">
             <div class="flex flex-column h-100">
                 <div class="gh-nav-body">
                     <div class="gh-nav-design-settings">
                         <div class="gh-stack">
+                            <header>
+                                <h1>Finishing touches</h1>
+                                <p class="gh-finishing-touches-subhed">You chose a theme, now it's time to make it your own.</p>
+                            </header>
                             {{#if this.descriptionVisible}}
                                 <Settings::FormFields::SiteDescription class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
                             {{/if}}
@@ -29,7 +28,7 @@
                     </div>
                 </div>
             </div>
-            <div class="pa4 gh-finishing-touches-button">
+            <div class="gh-finishing-touches-button">
                 <GhTaskButton
                     class="gh-btn gh-btn-large gh-btn-black gh-btn-icon w-100"
                     @task={{this.saveAndContinueTask}}
@@ -40,7 +39,7 @@
                 />
             </div>
         </div>
-        <div class="flex-grow-1 pa10">
+        <div class="gh-finishing-touches-preview">
             <GhBrowserPreview>
                 <GhHtmlIframe class="site-frame" @html={{this.themeManagement.previewHtml}} />
             </GhBrowserPreview>

--- a/app/templates/setup/finishing-touches.hbs
+++ b/app/templates/setup/finishing-touches.hbs
@@ -4,15 +4,27 @@
         <p>You chose a theme, now it's time to make it your own.</p>
     </header>
     <main class="flex flex-row h-100">
+        {{!-- {{this.activeTheme.name}} --}}
         <div class="gh-nav gh-nav-contextual gh-nav-design">
             <div class="flex flex-column h-100">
                 <div class="gh-nav-body">
                     <div class="gh-nav-design-settings">
                         <div class="gh-stack">
-                            <Settings::FormFields::SiteDescription class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
-                            <Settings::FormFields::AccentColor class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
-                            <Settings::FormFields::PublicationLogo class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
-                            <Settings::FormFields::PublicationCover class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
+                            {{#if this.descriptionVisible}}
+                                <Settings::FormFields::SiteDescription class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
+                            {{/if}}
+                            
+                            {{#if this.colorVisible}}
+                                <Settings::FormFields::AccentColor class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
+                            {{/if}}
+
+                            {{#if this.logoVisible}}
+                                <Settings::FormFields::PublicationLogo class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
+                            {{/if}}
+
+                            {{#if this.coverImageVisible}}
+                                <Settings::FormFields::PublicationCover class="gh-stack-item gh-setting" @didUpdate={{perform this.themeManagement.updatePreviewHtmlTask}} />
+                            {{/if}}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Added dynamic properties per theme: not all the properties (logo, cover image etc.) make sense for all the themes so we need to add a basic way to filter out the unwanted properteis.
- Removed showing the last modal (didn't remove the modal itself)
- Refined UI for finishing screen