### PR TITLE
🐛 Remove empty benefits before saving

### DIFF
--- a/app/components/modal-product.js
+++ b/app/components/modal-product.js
@@ -174,7 +174,7 @@ export default class ModalProductPrice extends ModalBase {
                 type: 'recurring'
             });
         }
-        this.product.set('benefits', this.benefits);
+        this.product.set('benefits', this.benefits.filter(benefit => !benefit.get('isBlank')));
         yield this.product.save();
 
         yield this.confirm();

--- a/tests/acceptance/settings/membership-test.js
+++ b/tests/acceptance/settings/membership-test.js
@@ -267,6 +267,17 @@ describe('Acceptance: Settings - Membership', function () {
         expect(find(`${modal} [data-test-tierpreview-benefits]`)).to.not.contain.text('First benefit');
         expect(findAll(`${modal} [data-test-tierpreview-benefits] li`).length).to.equal(1);
 
+        // Add a new benefit that we will later rename to an empty name
+        await fillIn(`${newBenefit} [data-test-input="benefit-label"]`, 'Third benefit');
+        await click(`${newBenefit} [data-test-button="add-benefit"]`);
+
+        expect(find(`${modal} [data-test-tierpreview-benefits]`)).to.contain.text('Third benefit');
+        expect(findAll(`${modal} [data-test-tierpreview-benefits] li`).length).to.equal(2);
+
+        // Clear the second benefit's name (it should get removed after saving)
+        const secondBenefitItem = `${modal} [data-test-benefit-item="1"]`;
+        await fillIn(`${secondBenefitItem} [data-test-input="benefit-label"]`, '');
+
         await click('[data-test-button="save-product"]');
 
         expect(find(`${modal}`)).to.not.exist;
@@ -274,6 +285,7 @@ describe('Acceptance: Settings - Membership', function () {
         expect(find('[data-test-product-card="free"] [data-test-description]')).to.contain.text('Test description');
         expect(find('[data-test-product-card="free"] [data-test-benefits]')).to.contain.text('Benefits (1)');
         expect(find('[data-test-product-card="free"] [data-test-benefits] li:nth-of-type(1)')).to.contain.text('Second benefit');
+        expect(findAll(`[data-test-product-card="free"] [data-test-benefits] li`).length).to.equal(1);
 
         const freeProduct = this.server.db.products.findBy({slug: 'free'});
         expect(freeProduct.description).to.equal('Test description');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1188

- The api throws a validation error when we try to add benefits with an empty name
- Before saving, we remove benefits with an empty name