### PR TITLE
🐛 Fixed sending non-integer prices to tiers api

### DIFF
--- a/app/components/gh-launch-wizard/finalise.js
+++ b/app/components/gh-launch-wizard/finalise.js
@@ -19,8 +19,8 @@ export default class GhLaunchWizardFinaliseComponent extends Component {
         const data = this.args.getData();
         this.product = data?.product;
         if (this.product) {
-            const monthlyAmount = data.monthlyAmount * 100;
-            const yearlyAmount = data.yearlyAmount * 100;
+            const monthlyAmount = Math.round(data.monthlyAmount * 100);
+            const yearlyAmount = Math.round(data.yearlyAmount * 100);
             const currency = data.currency;
             const monthlyPrice = {
                 nickname: 'Monthly',

--- a/app/components/gh-launch-wizard/set-pricing.js
+++ b/app/components/gh-launch-wizard/set-pricing.js
@@ -199,8 +199,8 @@ export default class GhLaunchWizardSetPricingComponent extends Component {
         const options = {
             disableBackground: true,
             currency: this.selectedCurrency.value,
-            monthlyPrice: this.stripeMonthlyAmount * 100,
-            yearlyPrice: this.stripeYearlyAmount * 100,
+            monthlyPrice: Math.round(this.stripeMonthlyAmount * 100),
+            yearlyPrice: Math.round(this.stripeYearlyAmount * 100),
             isMonthlyChecked: this.isMonthlyChecked,
             isYearlyChecked: this.isYearlyChecked,
             isFreeChecked: this.isFreeChecked,

--- a/app/components/gh-members-payments-setting.js
+++ b/app/components/gh-members-payments-setting.js
@@ -189,9 +189,9 @@ export default Component.extend({
                 if (plan.name !== 'Complimentary') {
                     let newAmount;
                     if (plan.interval === 'year') {
-                        newAmount = yearlyAmount * 100;
+                        newAmount = Math.round(yearlyAmount * 100);
                     } else if (plan.interval === 'month') {
-                        newAmount = monthlyAmount * 100;
+                        newAmount = Math.round(monthlyAmount * 100);
                     }
                     return Object.assign({}, plan, {
                         amount: newAmount

--- a/app/components/modal-product.js
+++ b/app/components/modal-product.js
@@ -155,8 +155,8 @@ export default class ModalProductPrice extends ModalBase {
         }
 
         if (!this.isFreeProduct) {
-            const monthlyAmount = this.stripeMonthlyAmount * 100;
-            const yearlyAmount = this.stripeYearlyAmount * 100;
+            const monthlyAmount = Math.round(this.stripeMonthlyAmount * 100);
+            const yearlyAmount = Math.round(this.stripeYearlyAmount * 100);
             this.product.set('monthlyPrice', {
                 nickname: 'Monthly',
                 amount: monthlyAmount,

--- a/app/controllers/settings/membership.js
+++ b/app/controllers/settings/membership.js
@@ -386,8 +386,8 @@ export default class MembersAccessController extends Controller {
     async saveProduct() {
         const isStripeConnected = this.settings.get('stripeConnectAccountId');
         if (this.product && isStripeConnected) {
-            const monthlyAmount = this.stripeMonthlyAmount * 100;
-            const yearlyAmount = this.stripeYearlyAmount * 100;
+            const monthlyAmount = Math.round(this.stripeMonthlyAmount * 100);
+            const yearlyAmount = Math.round(this.stripeYearlyAmount * 100);
 
             this.product.set('monthlyPrice', {
                 nickname: 'Monthly',

--- a/app/serializers/product.js
+++ b/app/serializers/product.js
@@ -1,0 +1,17 @@
+import ApplicationSerializer from './application';
+
+export default class ProductSerializer extends ApplicationSerializer {
+    serialize() {
+        let json = super.serialize(...arguments);
+
+        if (json?.monthly_price?.amount) {
+            json.monthly_price.amount = Math.round(json.monthly_price.amount);
+        }
+
+        if (json?.yearly_price?.amount) {
+            json.yearly_price.amount = Math.round(json.yearly_price.amount);
+        }
+
+        return json;
+    }
+}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1319

Due to how JS implements numbers, it's possible that when we multiple a number with 2 decimal places by 100 that we do not end up with an integer e.g. 9.95 * 100 = 994.999...

This is not a valid price for the API and so we must round it to the nearest integer. We round off prices both at source as well as in ties serializer to make sure we never send non integer prices to API.
