### PR TITLE
Added shortcut buttons to "Last seen" members filter datepicker

### DIFF
--- a/app/components/gh-date-picker.hbs
+++ b/app/components/gh-date-picker.hbs
@@ -1,5 +1,5 @@
 
-<div class="gh-date-picker">
+<div class="gh-date-picker" ...attributes>
     <PowerDatepicker
         @selected={{@value}}
         @center={{@value}}
@@ -8,7 +8,7 @@
         @disabled={{@disabled}}
         as |dp|
     >
-        <dp.Trigger @tabindex="-1" data-test-date-picker-trigger ...attributes>
+        <dp.Trigger @tabindex="-1" data-test-date-picker-trigger>
             <div class="{{if this.error "error"}}">
                 {{!-- template-lint-disable no-down-event-binding --}}
                 <input
@@ -28,8 +28,21 @@
             </div>
         </dp.Trigger>
         <dp.Content class="dropdown-menu">
-            <dp.Nav />
-            <dp.Days @minDate={{this.minDate}} @maxDate={{this.maxDate}} @weekdayFormat="min" />
+            {{#if (has-block)}}
+                {{yield (assign
+                    dp
+                    (hash
+                        select=this.onDateSelected
+                        Triger=null
+                        Content=null
+                        Nav=dp.Nav
+                        Days=(component dp.Days minDate=this.minDate maxDate=this.maxDate weekdayFormat="min")
+                    )
+                )}}
+            {{else}}
+                <dp.Nav />
+                <dp.Days @minDate={{this.minDate}} @maxDate={{this.maxDate}} @weekdayFormat="min" />
+            {{/if}}
         </dp.Content>
     </PowerDatepicker>
 

--- a/app/components/gh-date-picker.js
+++ b/app/components/gh-date-picker.js
@@ -82,7 +82,11 @@ export default class GhDatePicker extends Component {
 
     @action
     onDateSelected(datepickerEvent) {
-        this.setDate(datepickerEvent.id);
+        if (datepickerEvent instanceof moment) {
+            this.setDate(datepickerEvent.format(this.dateFormat));
+        } else {
+            this.setDate(datepickerEvent.id);
+        }
     }
 
     @action

--- a/app/components/members/filter-value.hbs
+++ b/app/components/members/filter-value.hbs
@@ -34,12 +34,30 @@
 
 {{else if (eq @filter.type 'last_seen_at')}}
     <GhDatePicker
+        class="gh-date-picker-with-shortcuts"
         @value={{@filter.value}}
         @maxDate={{now}}
         @maxDateError="Must be in the past"
         @onChange={{fn @setFilterValue @filter.type @filter.id}}
         data-test-input="members-filter-value"
-    />
+        as |datepicker|
+    >
+        <div class="flex flex-row">
+            <div class="br1">
+                <ol class="gh-date-picker-shortcuts">
+                    <li><button type="button" {{on "click" (fn datepicker.select (now))}}>Today</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 1 precision="days"))}}>Yesterday</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 7 precision="days"))}}>7 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 30 precision="days"))}}>30 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 90 precision="days"))}}>90 days ago</button></li>
+                </ol>
+            </div>
+            <div class="flex-grow-1">
+                <datepicker.Nav />
+                <datepicker.Days />
+            </div>
+        </div>
+    </GhDatePicker>
 
 {{else if (eq @filter.type 'created_at')}}
     <GhDatePicker

--- a/app/components/members/filter-value.hbs
+++ b/app/components/members/filter-value.hbs
@@ -42,19 +42,20 @@
         data-test-input="members-filter-value"
         as |datepicker|
     >
-        <div class="flex flex-row">
-            <div class="br1">
-                <ol class="gh-date-picker-shortcuts">
+        <div class="gh-date-picker-sh-container">
+            <div class="gh-date-picker-sh-calendar">
+                <datepicker.Nav />
+                <datepicker.Days />
+            </div>
+            <div class="gh-date-picker-shortcuts">
+                <h4>Jump to date</h4>
+                <ol>
                     <li><button type="button" {{on "click" (fn datepicker.select (moment-site-tz))}}>Today</button></li>
                     <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 1 precision="days"))}}>Yesterday</button></li>
                     <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 7 precision="days"))}}>7 days ago</button></li>
                     <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 30 precision="days"))}}>30 days ago</button></li>
                     <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 90 precision="days"))}}>90 days ago</button></li>
                 </ol>
-            </div>
-            <div class="flex-grow-1">
-                <datepicker.Nav />
-                <datepicker.Days />
             </div>
         </div>
     </GhDatePicker>

--- a/app/components/members/filter-value.hbs
+++ b/app/components/members/filter-value.hbs
@@ -50,11 +50,11 @@
             <div class="gh-date-picker-shortcuts">
                 <h4>Jump to date</h4>
                 <ol>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-site-tz))}}>Today</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 1 precision="days"))}}>Yesterday</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 7 precision="days"))}}>7 days ago</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 30 precision="days"))}}>30 days ago</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 90 precision="days"))}}>90 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.actions.select (moment-site-tz) datepicker)}}>Today</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.actions.select (moment-subtract (moment-site-tz) 1 precision="days") datepicker)}}>Yesterday</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.actions.select (moment-subtract (moment-site-tz) 7 precision="days") datepicker)}}>7 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.actions.select (moment-subtract (moment-site-tz) 30 precision="days") datepicker)}}>30 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.actions.select (moment-subtract (moment-site-tz) 90 precision="days") datepicker)}}>90 days ago</button></li>
                 </ol>
             </div>
         </div>

--- a/app/components/members/filter-value.hbs
+++ b/app/components/members/filter-value.hbs
@@ -45,11 +45,11 @@
         <div class="flex flex-row">
             <div class="br1">
                 <ol class="gh-date-picker-shortcuts">
-                    <li><button type="button" {{on "click" (fn datepicker.select (now))}}>Today</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 1 precision="days"))}}>Yesterday</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 7 precision="days"))}}>7 days ago</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 30 precision="days"))}}>30 days ago</button></li>
-                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract 90 precision="days"))}}>90 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-site-tz))}}>Today</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 1 precision="days"))}}>Yesterday</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 7 precision="days"))}}>7 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 30 precision="days"))}}>30 days ago</button></li>
+                    <li><button type="button" {{on "click" (fn datepicker.select (moment-subtract (moment-site-tz) 90 precision="days"))}}>90 days ago</button></li>
                 </ol>
             </div>
             <div class="flex-grow-1">

--- a/app/styles/components/power-calendar.css
+++ b/app/styles/components/power-calendar.css
@@ -236,3 +236,13 @@ svg.gh-date-picker-cal-icon {
     top: 9px;
     font-size: 1.3rem;
 }
+
+.gh-date-picker-with-shortcuts .ember-power-datepicker-content {
+    min-width: 300px;
+}
+
+.gh-date-picker-shortcuts {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}

--- a/app/styles/components/power-calendar.css
+++ b/app/styles/components/power-calendar.css
@@ -22,6 +22,7 @@
   flex: 1;
   text-align: center;
   font-size: 1.35rem;
+  font-weight: 600;
 }
 
 .ember-power-calendar-row {

--- a/app/styles/components/power-calendar.css
+++ b/app/styles/components/power-calendar.css
@@ -21,6 +21,7 @@
 .ember-power-calendar-nav-title {
   flex: 1;
   text-align: center;
+  font-size: 1.35rem;
 }
 
 .ember-power-calendar-row {
@@ -41,6 +42,7 @@
   justify-content: center;
   display: flex;
   align-items: center;
+  height: 23px;
 }
 
 .ember-power-calendar-day {
@@ -56,6 +58,7 @@
   align-items: center;
   justify-content: center;
   padding: 0;
+  height: 23px;
 }
 
 .ember-power-calendar-nav-control {
@@ -76,8 +79,7 @@
 }
 
 .ember-power-calendar-weekdays {
-  color: var(--darkgrey);
-  padding: 4px 0;
+  color: var(--midlightgrey);
 }
 
 .ember-power-calendar-day {
@@ -86,6 +88,7 @@
 
 .ember-power-calendar-nav {
   padding: 0 4px 8px;
+  height: 32px;
 }
 
 .ember-power-calendar-nav-control {
@@ -237,12 +240,53 @@ svg.gh-date-picker-cal-icon {
     font-size: 1.3rem;
 }
 
+.gh-date-picker-sh-container {
+    display: flex;
+    min-width: 380px;
+}
+
+.gh-date-picker-sh-calendar {
+    flex-basis: 213px;
+}
+
 .gh-date-picker-with-shortcuts .ember-power-datepicker-content {
     min-width: 300px;
 }
 
 .gh-date-picker-shortcuts {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    margin-left: 12px;
+    padding-left: 12px;
+    border-left: 1px solid var(--whitegrey);
+}
+
+.gh-date-picker-shortcuts h4 {
+    font-size: 1.35rem;
+    font-weight: 600;
+    margin: 0 5px 0;
+    height: 31px;
+    line-height: 24px;
+}
+
+.gh-date-picker-shortcuts ol {
     list-style: none;
     padding: 0;
     margin: 0;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin-bottom: 1px;
+}
+
+.gh-date-picker-shortcuts ol li {
+    height: 24px;
+}
+
+.gh-date-picker-shortcuts ol li button {
+    padding: 3px 6px;
+    border-radius: 3px;
+    font-size: 1.4rem;
 }

--- a/tests/integration/components/gh-date-picker-test.js
+++ b/tests/integration/components/gh-date-picker-test.js
@@ -341,4 +341,23 @@ describe('Integration: Component: gh-date-picker', function () {
             expect(find('[data-test-date-picker-error]')).to.have.text('Must be in the past');
         });
     });
+
+    describe('block invocation', function () {
+        it('exposes Nav and Days components', async function () {
+            clock = sinon.useFakeTimers({
+                now: moment('2022-02-02 22:22:22.000Z').toDate()
+            });
+
+            this.set('date', moment('2022-02-02 22:22:22.000Z')).toDate();
+            this.set('maxDate', moment('2022-02-05 12:00:00.000Z').toDate());
+
+            await render(hbs`<GhDatePicker @value={{this.date}} @maxDate={{this.maxDate}} as |dp|><dp.Nav /><dp.Days /></GhDatePicker>`);
+
+            await click('[data-test-date-picker-trigger]');
+
+            // calendar is rendered with the right maxDate value curried
+            expect(find('[data-date="2022-02-10"]')).to.have.attribute('disabled');
+            expect(find('[data-date="2022-02-25"]')).to.have.attribute('disabled');
+        });
+    });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1410

- added block invocation support to `<GhDatePicker>` that exposes the calendar components used inside the datepicker dropdown allowing for customisation of the dropdown content
- updated "last seen" datepicker to use the block invocation support to add buttons that select typical "time ago" dates
