### PR TITLE
Added tier visibility handling from portal settings

### DIFF
--- a/app/components/gh-launch-wizard/connect-stripe.js
+++ b/app/components/gh-launch-wizard/connect-stripe.js
@@ -88,10 +88,7 @@ export default class GhLaunchWizardConnectStripeComponent extends Component {
 
             try {
                 const updatedProduct = yield this.product.save();
-                const existingPortalProducts = this.settings.get('portalProducts');
-                if (!existingPortalProducts?.length) {
-                    this.settings.set('portalProducts', [updatedProduct.id]);
-                }
+
                 yield this.settings.save();
 
                 return updatedProduct;

--- a/app/components/gh-members-payments-setting.js
+++ b/app/components/gh-members-payments-setting.js
@@ -303,12 +303,9 @@ export default Component.extend({
             try {
                 let response = yield this.settings.save();
 
-                const product = yield this.saveProduct.perform();
+                yield this.saveProduct.perform();
                 this.settings.set('portalPlans', ['free', 'monthly', 'yearly']);
-                const existingPortalProducts = this.settings.get('portalProducts');
-                if (!existingPortalProducts?.length) {
-                    this.settings.set('portalProducts', [product.id]);
-                }
+
                 response = yield this.settings.save();
 
                 this.set('membersStripeOpen', false);

--- a/app/models/product.js
+++ b/app/models/product.js
@@ -9,6 +9,7 @@ export default Model.extend(ValidationEngine, {
     active: attr('boolean'),
     slug: attr('string'),
     welcomePageURL: attr('string'),
+    visibility: attr('string'),
     type: attr('string', {defaultValue: 'paid'}),
     monthlyPrice: attr('stripe-price'),
     yearlyPrice: attr('stripe-price'),

--- a/app/services/members-utils.js
+++ b/app/services/members-utils.js
@@ -4,6 +4,7 @@ export default class MembersUtilsService extends Service {
     @service config;
     @service settings;
     @service feature;
+    @service store;
 
     get isMembersEnabled() {
         return this.settings.get('membersSignupAccess') !== 'none';
@@ -77,7 +78,7 @@ export default class MembersUtilsService extends Service {
     // Portal preview ----------------------------------------------------------
 
     getPortalPreviewUrl(overrides) {
-        const {
+        let {
             disableBackground = false,
             page = 'signup',
             button = this.settings.get('portalButton'),
@@ -88,10 +89,16 @@ export default class MembersUtilsService extends Service {
             monthlyPrice,
             yearlyPrice,
             portalPlans = this.settings.get('portalPlans'),
-            portalProducts = this.settings.get('portalProducts'),
+            portalProducts,
             currency,
             membersSignupAccess = this.settings.get('membersSignupAccess')
         } = overrides;
+
+        const tiers = this.store.peekAll('product') || [];
+
+        portalProducts = portalProducts || tiers.filter((t) => {
+            return t.visibility === 'public' && t.type === 'paid';
+        }).map(t => t.id);
 
         const baseUrl = this.config.get('blogUrl');
         const portalBase = '/#/portal/preview';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1387

This will allow us to move from the portal_products and portal_plans settings to using the visibility property on tiers to determine whether or not a tier should be visible in Portal. This updates admin to handle tier visibility property based on changes in settings. Old portal settings update is temporarily kept in though will not be used for determining visibility going forward. Also removes default product visibility being set on stripe connect.
