### PR TITLE
Resolved deprecation warnings for dynamic modal component binding

### DIFF
--- a/app/components/gh-email-preview-link.js
+++ b/app/components/gh-email-preview-link.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import EmailPreviewModal from './modals/email-preview';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
@@ -8,6 +9,6 @@ export default class GhEmailPreviewLink extends Component {
     @action
     openPreview(event) {
         event.preventDefault();
-        return this.modals.open('modals/email-preview', this.args.data);
+        return this.modals.open(EmailPreviewModal, this.args.data);
     }
 }

--- a/app/components/gh-nav-menu/main.js
+++ b/app/components/gh-nav-menu/main.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import SearchModal from '../modals/search';
 import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
 import classic from 'ember-classic-decorator';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
@@ -101,7 +102,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
     @action
     openSearchModal() {
-        return this.modals.open('modals/search');
+        return this.modals.open(SearchModal);
     }
 
     @action

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import ConfirmPublishModal from './modals/editor/confirm-publish';
 import EmailFailedError from 'ghost-admin/errors/email-failed-error';
 import {bind, schedule} from '@ember/runloop';
 import {computed} from '@ember/object';
@@ -386,7 +387,7 @@ export default Component.extend({
                 options.dropdown.actions.close();
             }
 
-            return yield this.modals.open('modals/editor/confirm-publish', {
+            return yield this.modals.open(ConfirmPublishModal, {
                 post: this.post,
                 emailOnly: this.emailOnly,
                 sendEmailWhenPublished: this.sendEmailWhenPublished,

--- a/app/components/gh-theme-table.js
+++ b/app/components/gh-theme-table.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import ConfirmDeleteThemeModal from './modals/design/confirm-delete-theme';
 import {action, get} from '@ember/object';
 import {inject as service} from '@ember/service';
 
@@ -89,7 +90,7 @@ export default class GhThemeTableComponent extends Component {
     deleteTheme(theme, dropdown) {
         dropdown?.actions.close();
 
-        this.confirmDeleteModal = this.modals.open('modals/design/confirm-delete-theme', {
+        this.confirmDeleteModal = this.modals.open(ConfirmDeleteThemeModal, {
             theme
         }).finally(() => {
             this.confirmDeleteModal = null;

--- a/app/components/modals/custom-view-form.js
+++ b/app/components/modals/custom-view-form.js
@@ -8,6 +8,10 @@ export default class CustomViewFormModal extends Component {
     @service customViews;
     @service router;
 
+    static modalOptions = {
+        className: 'fullscreen-modal-action fullscreen-modal-narrow'
+    };
+
     @action
     changeColor(event) {
         const color = event.target.value;

--- a/app/components/modals/delete-post.js
+++ b/app/components/modals/delete-post.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default class DeletePostModalComponent extends Component {
+export default class DeletePostModal extends Component {
     @service notifications;
     @service router;
 

--- a/app/components/modals/design/confirm-delete-theme.js
+++ b/app/components/modals/design/confirm-delete-theme.js
@@ -3,7 +3,7 @@ import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default class ConfirmDeleteThemeComponent extends Component {
+export default class ConfirmDeleteThemeModal extends Component {
     @service ghostPaths;
     @service notifications;
     @service utils;

--- a/app/components/modals/design/install-theme.js
+++ b/app/components/modals/design/install-theme.js
@@ -4,7 +4,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class InstallThemeModalComponent extends Component {
+export default class InstallThemeModal extends Component {
     @service ajax;
     @service ghostPaths;
     @service store;

--- a/app/components/modals/design/upload-theme.js
+++ b/app/components/modals/design/upload-theme.js
@@ -9,11 +9,19 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class UploadThemeModalComponent extends Component {
+export default class UploadThemeModal extends Component {
     @service eventBus;
     @service ghostPaths;
     @service store;
     @service themeManagement;
+
+    static modalOptions = {
+        beforeClose: () => {
+            if (this.themeManagement.isUploading) {
+                return false;
+            }
+        }
+    };
 
     @tracked displayOverwriteWarning = false;
     @tracked file;

--- a/app/components/modals/design/view-theme.js
+++ b/app/components/modals/design/view-theme.js
@@ -1,11 +1,17 @@
 import Component from '@glimmer/component';
+import InstallThemeModal from './install-theme';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
-export default class ViewThemeModalComponent extends Component {
+export default class ViewThemeModal extends Component {
     @service modals;
     @service router;
+
+    static modalOptions = {
+        className: 'fullscreen-modal-total-overlay',
+        omitBackdrop: true
+    };
 
     @tracked previewSize = 'desktop';
 
@@ -30,7 +36,7 @@ export default class ViewThemeModalComponent extends Component {
 
     @action
     installTheme() {
-        this.installModal = this.modals.open('modals/design/install-theme', {
+        this.installModal = this.modals.open(InstallThemeModal, {
             theme: this.args.data.theme,
             onSuccess: () => {
                 this.showingSuccessModal = true;

--- a/app/components/modals/editor/confirm-publish.js
+++ b/app/components/modals/editor/confirm-publish.js
@@ -4,7 +4,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class ModalsEditorConfirmPublishComponent extends Component {
+export default class ConfirmPublishModal extends Component {
     @service membersCountCache;
     @service session;
     @service store;

--- a/app/components/modals/email-preview.js
+++ b/app/components/modals/email-preview.js
@@ -21,6 +21,10 @@ export default class EmailPreviewModal extends Component {
     @service ghostPaths;
     @service settings;
 
+    static modalOptions = {
+        className: 'fullscreen-modal-full-overlay fullscreen-modal-email-preview'
+    };
+
     @tracked tab = 'desktop';
     @tracked subject = null;
 

--- a/app/components/modals/members/bulk-add-label.js
+++ b/app/components/modals/members/bulk-add-label.js
@@ -4,7 +4,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class MembersBulkAddLabelModal extends Component {
+export default class BulkAddMembersLabelModal extends Component {
     @service ajax;
     @service ghostPaths;
 

--- a/app/components/modals/members/bulk-delete.js
+++ b/app/components/modals/members/bulk-delete.js
@@ -7,7 +7,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class MembersBulkDeleteModal extends Component {
+export default class BulkDeleteMembersModal extends Component {
     @service ajax;
     @service ghostPaths;
 

--- a/app/components/modals/members/bulk-remove-label.js
+++ b/app/components/modals/members/bulk-remove-label.js
@@ -4,7 +4,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class MembersBulkRemoveLabelModal extends Component {
+export default class BulkRemoveMembersLabelModal extends Component {
     @service ajax;
     @service ghostPaths;
 

--- a/app/components/modals/members/bulk-unsubscribe.js
+++ b/app/components/modals/members/bulk-unsubscribe.js
@@ -4,7 +4,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class MembersBulkUnsubscribeModal extends Component {
+export default class BulkUnsubscribeMembersModal extends Component {
     @service ajax;
     @service ghostPaths;
 

--- a/app/components/modals/new-custom-integration.js
+++ b/app/components/modals/new-custom-integration.js
@@ -7,7 +7,7 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class NewCustomIntegrationModalComponent extends Component {
+export default class NewCustomIntegrationModal extends Component {
     @service router;
     @service store;
 

--- a/app/components/modals/offers/archive.js
+++ b/app/components/modals/offers/archive.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default class ArchiveOfferModalComponent extends Component {
+export default class ArchiveOfferModal extends Component {
     @service notifications;
     @service router;
 

--- a/app/components/modals/offers/link.js
+++ b/app/components/modals/offers/link.js
@@ -4,7 +4,7 @@ import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
-export default class ModalsOffersLinkComponent extends Component {
+export default class LinkOfferModal extends Component {
     @service config;
 
     constructor() {

--- a/app/components/modals/offers/unarchive.js
+++ b/app/components/modals/offers/unarchive.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default class ArchiveOfferModalComponent extends Component {
+export default class UnarchiveOfferModal extends Component {
     @service notifications;
     @service router;
 

--- a/app/components/modals/post-preview.js
+++ b/app/components/modals/post-preview.js
@@ -4,10 +4,16 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class ModalPostPreviewComponent extends Component {
-    @tracked tab = 'browser';
+export default class PostPreviewModal extends Component {
     @service settings;
     @service session;
+
+    static modalOptions = {
+        className: 'fullscreen-modal-full-overlay fullscreen-modal-email-preview',
+        focusTrapOptions: null // not ideal but date inputs aren't focusable otherwise
+    };
+
+    @tracked tab = 'browser';
 
     constructor() {
         super(...arguments);

--- a/app/components/modals/search.js
+++ b/app/components/modals/search.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
 
-export default class SearchModalComponent extends Component {
+export default class SearchModal extends Component {
     @action
     focusFirstInput(mouseEvent) {
         mouseEvent.target.querySelector('input')?.focus();

--- a/app/components/modals/tiers/archive.js
+++ b/app/components/modals/tiers/archive.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default class ArchiveTierModalComponent extends Component {
+export default class ArchiveTierModal extends Component {
     @service notifications;
     @service router;
 

--- a/app/components/modals/tiers/unarchive.js
+++ b/app/components/modals/tiers/unarchive.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default class UnarchiveTierModalComponent extends Component {
+export default class UnarchiveTierModal extends Component {
     @service notifications;
     @service router;
 

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -1,5 +1,8 @@
+import ConfirmEditorLeaveModal from '../components/modals/editor/confirm-leave';
 import Controller, {inject as controller} from '@ember/controller';
+import DeletePostModal from '../components/modals/delete-post';
 import PostModel from 'ghost-admin/models/post';
+import PostPreviewModal from '../components/modals/post-preview';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import classic from 'ember-classic-decorator';
 import config from 'ghost-admin/config/environment';
@@ -251,10 +254,8 @@ export default class EditorController extends Controller {
     @action
     openDeletePostModal() {
         if (!this.get('post.isNew')) {
-            this.modals.open('modals/delete-post', {
+            this.modals.open(DeletePostModal, {
                 post: this.post
-            }, {
-                className: 'fullscreen-modal fullscreen-modal-action fullscreen-modal-wide'
             });
         }
     }
@@ -272,16 +273,12 @@ export default class EditorController extends Controller {
 
     @action
     openPostPreviewModal() {
-        this.modals.open('modals/post-preview', {
+        this.modals.open(PostPreviewModal, {
             post: this.post,
             saveTask: this.saveTask,
             hasDirtyAttributes: this.hasDirtyAttributes,
-            // TODO: update to call action method directly when switching to class syntax
-            setEditorSaveType: this.actions.setSaveType.bind(this),
+            setEditorSaveType: this.setSaveType,
             memberCount: this.memberCount
-        }, {
-            className: 'fullscreen-modal fullscreen-modal-full-overlay fullscreen-modal-email-preview',
-            focusTrapOptions: null // not ideal but date inputs aren't focusable otherwise
         });
     }
 
@@ -882,7 +879,7 @@ export default class EditorController extends Controller {
             }
             console.log('showing leave editor modal', this._leaveModalReason); // eslint-disable-line
 
-            const reallyLeave = await this.modals.open('modals/editor/confirm-leave');
+            const reallyLeave = await this.modals.open(ConfirmEditorLeaveModal);
 
             if (reallyLeave !== true) {
                 return;

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -1,3 +1,7 @@
+import BulkAddMembersLabelModal from '../components/modals/members/bulk-add-label';
+import BulkDeleteMembersModal from '../components/modals/members/bulk-delete';
+import BulkRemoveMembersLabelModal from '../components/modals/members/bulk-remove-label';
+import BulkUnsubscribeMembersModal from '../components/modals/members/bulk-unsubscribe';
 import Controller from '@ember/controller';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import moment from 'moment';
@@ -309,7 +313,7 @@ export default class MembersController extends Controller {
 
     @action
     bulkAddLabel() {
-        this.modals.open('modals/members/bulk-add-label', {
+        this.modals.open(BulkAddMembersLabelModal, {
             query: this.getApiQueryObject(),
             onComplete: this.resetAndReloadMembers
         });
@@ -317,7 +321,7 @@ export default class MembersController extends Controller {
 
     @action
     bulkRemoveLabel() {
-        this.modals.open('modals/members/bulk-remove-label', {
+        this.modals.open(BulkRemoveMembersLabelModal, {
             query: this.getApiQueryObject(),
             onComplete: this.resetAndReloadMembers
         });
@@ -325,7 +329,7 @@ export default class MembersController extends Controller {
 
     @action
     bulkUnsubscribe() {
-        this.modals.open('modals/members/bulk-unsubscribe', {
+        this.modals.open(BulkUnsubscribeMembersModal, {
             query: this.getApiQueryObject(),
             onComplete: this.resetAndReloadMembers
         });
@@ -339,7 +343,7 @@ export default class MembersController extends Controller {
 
     @action
     bulkDelete() {
-        this.modals.open('modals/members/bulk-delete', {
+        this.modals.open(BulkDeleteMembersModal, {
             query: this.getApiQueryObject(),
             onComplete: () => {
                 // reset, clear filters, and reload list and counts

--- a/app/controllers/offer.js
+++ b/app/controllers/offer.js
@@ -1,4 +1,6 @@
+import ArchiveOfferModal from '../components/modals/offers/archive';
 import Controller, {inject as controller} from '@ember/controller';
+import UnarchiveOfferModal from '../components/modals/offers/unarchive';
 import config from 'ghost-admin/config/environment';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import {action} from '@ember/object';
@@ -347,10 +349,8 @@ export default class OffersController extends Controller {
     @action
     openConfirmArchiveModal() {
         if (!this.offer.isNew) {
-            this.modals.open('modals/offers/archive', {
+            this.modals.open(ArchiveOfferModal, {
                 offer: this.offer
-            }, {
-                className: 'fullscreen-modal fullscreen-modal-action fullscreen-modal-wide'
             });
         }
     }
@@ -358,10 +358,8 @@ export default class OffersController extends Controller {
     @action
     openConfirmUnarchiveModal() {
         if (!this.offer.isNew) {
-            this.modals.open('modals/offers/unarchive', {
+            this.modals.open(UnarchiveOfferModal, {
                 offer: this.offer
-            }, {
-                className: 'fullscreen-modal fullscreen-modal-action fullscreen-modal-wide'
             });
         }
     }

--- a/app/controllers/offers.js
+++ b/app/controllers/offers.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import LinkOfferModal from '../components/modals/offers/link';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -65,10 +66,8 @@ export default class MembersController extends Controller {
 
     @action
     openLinkDialog(offer) {
-        this.advancedModal = this.modals.open('modals/offers/link', {
+        this.advancedModal = this.modals.open(LinkOfferModal, {
             offer: offer
-        }, {
-            className: 'fullscreen-modal-action fullscreen-modal-wide'
         });
     }
 

--- a/app/routes/settings/design/change-theme/install.js
+++ b/app/routes/settings/design/change-theme/install.js
@@ -1,6 +1,6 @@
 import AdminRoute from 'ghost-admin/routes/admin';
+import InstallThemeModal from '../../../../components/modals/design/install-theme';
 import {action} from '@ember/object';
-import {bind} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
 export default class InstallThemeRoute extends AdminRoute {
@@ -23,7 +23,7 @@ export default class InstallThemeRoute extends AdminRoute {
 
         const theme = themesController.officialThemes.findBy('ref', installController.ref);
 
-        this.installModal = this.modals.open('modals/design/install-theme', {
+        this.installModal = this.modals.open(InstallThemeModal, {
             theme,
             ref: installController.ref,
             onSuccess: () => {
@@ -31,7 +31,7 @@ export default class InstallThemeRoute extends AdminRoute {
                 this.router.transitionTo('settings.design');
             }
         }, {
-            beforeClose: bind(this, this.beforeModalClose)
+            beforeClose: this.beforeModalClose
         });
     }
 
@@ -44,6 +44,7 @@ export default class InstallThemeRoute extends AdminRoute {
         }
     }
 
+    @action
     beforeModalClose() {
         if (!this.showingSuccessModal) {
             this.transitionTo('settings.design.change-theme');

--- a/app/routes/settings/design/change-theme/view.js
+++ b/app/routes/settings/design/change-theme/view.js
@@ -1,4 +1,5 @@
 import AdminRoute from 'ghost-admin/routes/admin';
+import ViewThemeModal from 'ghost-admin/components/modals/design/view-theme';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
@@ -24,7 +25,7 @@ export default class ViewThemeRoute extends AdminRoute {
     setupController(controller, model) {
         this.themeModal?.close();
 
-        this.themeModal = this.modals.open('modals/design/view-theme', {
+        this.themeModal = this.modals.open(ViewThemeModal, {
             theme: model
         }, {
             beforeClose: this.beforeModalClose

--- a/app/routes/settings/design/index.js
+++ b/app/routes/settings/design/index.js
@@ -1,4 +1,5 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import ConfirmUnsavedChangesModal from '../../../components/modals/confirm-unsaved-changes';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
@@ -40,7 +41,7 @@ export default class SettingsDesignIndexRoute extends AuthenticatedRoute {
         }
 
         if (!this.confirmModal) {
-            this.confirmModal = this.modals.open('modals/confirm-unsaved-changes')
+            this.confirmModal = this.modals.open(ConfirmUnsavedChangesModal)
                 .then((discardChanges) => {
                     if (discardChanges === true) {
                         this.settings.rollbackAttributes();

--- a/app/routes/settings/integrations/new.js
+++ b/app/routes/settings/integrations/new.js
@@ -1,4 +1,6 @@
 import AdminRoute from 'ghost-admin/routes/admin';
+import CustomIntegrationLimitsModal from '../../../components/modals/limits/custom-integration';
+import NewCustomIntegrationModal from '../../../components/modals/new-custom-integration';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
@@ -14,7 +16,7 @@ export default class NewIntegrationRoute extends AdminRoute {
             try {
                 await this.limit.limiter.errorIfWouldGoOverLimit('customIntegrations');
             } catch (error) {
-                this.modal = this.modals.open('modals/limits/custom-integration', {
+                this.modal = this.modals.open(CustomIntegrationLimitsModal, {
                     message: error.message
                 }, {
                     beforeClose: this.beforeModalClose
@@ -23,7 +25,7 @@ export default class NewIntegrationRoute extends AdminRoute {
             }
         }
 
-        this.modal = this.modals.open('modals/new-custom-integration', {}, {
+        this.modal = this.modals.open(NewCustomIntegrationModal, {}, {
             beforeClose: this.beforeModalClose
         });
     }

--- a/app/services/custom-views.js
+++ b/app/services/custom-views.js
@@ -1,3 +1,4 @@
+import CustomViewFormModal from '../components/modals/custom-view-form';
 import EmberObject, {action} from '@ember/object';
 import Service, {inject as service} from '@ember/service';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
@@ -228,7 +229,7 @@ export default class CustomViewsService extends Service {
     editView() {
         const customView = CustomView.create(this.activeView || this.newView());
 
-        return this.modals.open('modals/custom-view-form', {
+        return this.modals.open(CustomViewFormModal, {
             customView
         });
     }

--- a/app/services/modals.js
+++ b/app/services/modals.js
@@ -4,30 +4,9 @@ import {inject as service} from '@ember/service';
 
 export default class ModalsService extends EPMModalsService {
     @service dropdown;
-    @service themeManagement;
 
     DEFAULT_OPTIONS = {
         className: 'fullscreen-modal-action fullscreen-modal-wide'
-    };
-
-    MODAL_OPTIONS = {
-        'modals/custom-view-form': {
-            className: 'fullscreen-modal-action fullscreen-modal-narrow'
-        },
-        'modals/email-preview': {
-            className: 'fullscreen-modal-full-overlay fullscreen-modal-email-preview'
-        },
-        'modals/design/upload-theme': {
-            beforeClose: () => {
-                if (this.themeManagement.isUploading) {
-                    return false;
-                }
-            }
-        },
-        'modals/design/view-theme': {
-            className: 'fullscreen-modal-total-overlay',
-            omitBackdrop: true
-        }
     };
 
     // we manually close modals on backdrop clicks and escape rather than letting focus-trap
@@ -39,7 +18,7 @@ export default class ModalsService extends EPMModalsService {
     };
 
     open(modal, data, options) {
-        const mergedOptions = Object.assign({}, this.DEFAULT_OPTIONS, this.MODAL_OPTIONS[modal], options);
+        const mergedOptions = Object.assign({}, this.DEFAULT_OPTIONS, modal.modalOptions, options);
         return super.open(modal, data, mergedOptions);
     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/559
refs https://github.com/TryGhost/Admin/commit/4cbb56a0df879e0e0a6e7ba4a9e31697b22d8f5e

- with the update of `ember-promise-modals` we started to get deprecation warnings when using `modals.open('modal-component-name')`
  - upcoming Ember build updates will introduce tree shaking but using run-time lookup of modal components by name works against that because it's not statically analysable
- switched to importing components and passing the component class directly, eg. `modals.open(ModalComponent)`
- standardized modal component class names with a `MyModal` style to get better behaviour in code editors when it auto generates imports
- dropped the modal defaults from the modals service because we can now use a static `modalOptions` property on the modal components themselves when we want to override the defaults
