### PR TITLE
🐛 Fixed error on saving a paid member

### DIFF
--- a/app/components/gh-member-settings-form.js
+++ b/app/components/gh-member-settings-form.js
@@ -79,15 +79,15 @@ export default class extends Component {
                 isComplimentary: !sub.id
             };
         });
-
-        for (let product of products) {
+        return products.map((product) => {
             let productSubscriptions = subscriptionData.filter((subscription) => {
                 return subscription?.price?.product?.product_id === (product.product_id || product.id);
             });
-            product.subscriptions = productSubscriptions;
-        }
-
-        return products;
+            return {
+                ...product,
+                subscriptions: productSubscriptions
+            };
+        });
     }
 
     get customer() {

--- a/tests/acceptance/members/details-test.js
+++ b/tests/acceptance/members/details-test.js
@@ -151,6 +151,8 @@ describe('Acceptance: Member details', function () {
 
         expect(findAll('[data-test-subscription]').length, 'displays all member subscriptions')
             .to.equal(2);
+        await click('[data-test-button="save"]');
+        expect(find('[data-test-button="save"]')).to.not.contain.text('Retry');
     });
 
     it('displays correctly one canceled subscription', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1435
refs https://github.com/TryGhost/Admin/commit/f5f69d01b16cc2ed6c523258cdc47a818da71cd1

A recent change for showing all subscriptions of a member on detail screen introduced a circular json structure with subscription -> tiers -> subscriptions, which throws an error on saving any member with paid subscription on member detail screen.
