### PR TITLE
Added `multiple-newsletters` branch to CI trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "v4.*"
       - "5.0"
+      - "multiple-newsletters"
       - main
       - "renovate/*"
 jobs:


### PR DESCRIPTION
Currently the CI doesn't run in the new `multiple-newsletters` branch.
