### PR TITLE
🎨 add link to github release for current version

### DIFF
--- a/app/templates/whatsnew.hbs
+++ b/app/templates/whatsnew.hbs
@@ -50,7 +50,7 @@
                 {{/if}}
 
                 <ul class="gh-env-list">
-                    <li><strong>Version:</strong> {{this.config.version}}</li>
+                    <li><strong>Version:</strong> <a href="https://github.com/TryGhost/Ghost/releases/tag/v{{this.config.version}}" target="_blank" rel="noopener noreferrer">{{this.config.version}}</a></li>
                     {{#if this.showSystemInfo}}
                     <li><strong>Environment:</strong> <span class="ttc">{{this.config.environment}}</span></li>
                     <li class="gh-env-list-database-type"><strong>Database:</strong> {{this.config.database}}</li>


### PR DESCRIPTION
When Ghost has an available update, the message we see provides a link to the release on Github for that version. If there is no update available, it would be nice if the version still linked to the relevant release on Github. I often find myself checking the release page out a couple of times each release, to see what has been updated, fixed, added etc... so this is a more convenient way of getting to that page.