### PR TITLE
Renamed `/email_preview` endpoint to `/email_previews`

### DIFF
--- a/app/components/gh-post-settings-menu/email.js
+++ b/app/components/gh-post-settings-menu/email.js
@@ -87,7 +87,7 @@ export default class Email extends Component {
                 return false;
             }
             this.set('sendTestEmailError', '');
-            const url = this.ghostPaths.url.api('/email_preview/posts', resourceId);
+            const url = this.ghostPaths.url.api('/email_previews/posts', resourceId);
             const data = {emails: [testEmail]};
             const options = {
                 data,

--- a/app/components/modals/email-preview.js
+++ b/app/components/modals/email-preview.js
@@ -66,7 +66,7 @@ export default class EmailPreviewModal extends Component {
             subject = this.args.data.email.subject;
         // data is a post? try fetching email preview
         } else {
-            let url = this.ghostPaths.url.api('/email_preview/posts', this.args.data.id);
+            let url = this.ghostPaths.url.api('/email_previews/posts', this.args.data.id);
             let response = await this.ajax.request(url);
             let [emailPreview] = response.email_previews;
             html = emailPreview.html;

--- a/app/components/modals/post-preview/email.js
+++ b/app/components/modals/post-preview/email.js
@@ -77,7 +77,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
             }
             this.sendPreviewEmailError = '';
 
-            const url = this.ghostPaths.url.api('/email_preview/posts', resourceId);
+            const url = this.ghostPaths.url.api('/email_previews/posts', resourceId);
             const data = {emails: [testEmail], memberSegment: this.memberSegment};
             const options = {
                 data,
@@ -122,7 +122,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
             subject = post.email.subject;
         // model is a post, fetch email preview
         } else {
-            let url = new URL(this.ghostPaths.url.api('/email_preview/posts', post.id), window.location.href);
+            let url = new URL(this.ghostPaths.url.api('/email_previews/posts', post.id), window.location.href);
             url.searchParams.set('memberSegment', this.memberSegment);
 
             let response = await this.ajax.request(url.href);


### PR DESCRIPTION
🚧 