### PR TITLE
Updated route for newsletter settings

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -45,9 +45,9 @@ Router.map(function () {
     this.route('settings.members-email', {path: '/settings/members-email'});
     this.route('settings.code-injection', {path: '/settings/code-injection'});
 
-    this.route('settings.members-email-labs', {path: '/settings/members-email-labs'}, function () {
-        this.route('new-newsletter', {path: '/newsletters/new'});
-        this.route('edit-newsletter', {path: '/newsletters/:newsletter_id'});
+    this.route('settings.members-email-labs', {path: '/settings/newsletters'}, function () {
+        this.route('new-newsletter', {path: 'new'});
+        this.route('edit-newsletter', {path: ':newsletter_id'});
     });
 
     this.route('settings.design', {path: '/settings/design'}, function () {

--- a/mirage/config/newsletters.js
+++ b/mirage/config/newsletters.js
@@ -62,7 +62,7 @@ export default function mockNewsletters(server) {
             };
             const token = btoa(JSON.stringify(tokenData));
             const baseUrl = window.location.href.replace(window.location.hash, '');
-            const verifyUrl = `${baseUrl}settings/members-email-labs/?verifyEmail=${token}`;
+            const verifyUrl = `${baseUrl}settings/newsletters/?verifyEmail=${token}`;
             // eslint-disable-next-line
             console.warn('Verification email sent. Mocked verification URL:', verifyUrl);
         }

--- a/tests/acceptance/settings/members-email-labs-test.js
+++ b/tests/acceptance/settings/members-email-labs-test.js
@@ -23,19 +23,19 @@ describe('Acceptance: Settings - Members email (multipleNewsletters)', function 
 
     it('without flag - redirects labs to original', async function () {
         disableLabsFlag(this.server, 'multipleNewsletters');
-        await visit('/settings/members-email-labs');
+        await visit('/settings/newsletters');
         expect(currentURL()).to.equal('/settings/members-email');
     });
 
     it('with flag - redirects original to labs', async function () {
         await visit('/settings/members-email');
-        expect(currentURL()).to.equal('/settings/members-email-labs');
+        expect(currentURL()).to.equal('/settings/newsletters');
     });
 
     it('can manage open rate tracking', async function () {
         this.server.db.settings.update({key: 'email_track_opens'}, {value: 'true'});
 
-        await visit('/settings/members-email-labs');
+        await visit('/settings/newsletters');
         expect(find('[data-test-checkbox="email-track-opens"]')).to.be.checked;
 
         await click('[data-test-label="email-track-opens"]');


### PR DESCRIPTION
- updates newsletter settings route to `/settings/newsletters` for GA
