### PR TITLE
Added disabled newsletter dropdown to scheduled state of publish menu

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -3,7 +3,7 @@ module.exports = {
 
     rules: {
         'no-forbidden-elements': ['meta', 'html', 'script'],
-        'no-implicit-this': {allow: ['now', 'site-icon-style', 'accent-color-background']},
+        'no-implicit-this': {allow: ['noop', 'now', 'site-icon-style', 'accent-color-background']},
         'no-inline-styles': false
     }
 };

--- a/app/components/gh-publishmenu-scheduled.hbs
+++ b/app/components/gh-publishmenu-scheduled.hbs
@@ -38,6 +38,24 @@
                         <div class="gh-publishmenu-email-label pe-none">
                             <label class="gh-publishmenu-radio-label mb3 midgrey">Send by email to</label>
 
+                            {{#if (and (feature "multipleNewsletters") (gt @availableNewsletters.length 1))}}
+                                <div class="mb3">
+                                    <PowerSelect
+                                        @selected={{@post.newsletter}}
+                                        @options={{@availableNewsletters}}
+                                        @onChange={{noop}}
+                                        @triggerComponent="gh-power-select/trigger"
+                                        @triggerClass="gh-publishmenu-newsletter-trigger"
+                                        @dropdownClass="gh-publishmenu-newsletter-dropdown"
+                                        @renderInPlace={{true}}
+                                        @disabled={{true}}
+                                        as |newsletter|
+                                    >
+                                        {{newsletter.name}}
+                                    </PowerSelect>
+                                </div>
+                            {{/if}}
+
                             <div class="form-group">
                                 <GhMembersRecipientSelect
                                     @filter={{@recipientsFilter}}

--- a/app/components/gh-publishmenu-scheduled.hbs
+++ b/app/components/gh-publishmenu-scheduled.hbs
@@ -41,7 +41,7 @@
                             {{#if (and (feature "multipleNewsletters") (gt @availableNewsletters.length 1))}}
                                 <div class="mb3">
                                     <PowerSelect
-                                        @selected={{@post.newsletter}}
+                                        @selected={{this.selectedNewsletter}}
                                         @options={{@availableNewsletters}}
                                         @onChange={{noop}}
                                         @triggerComponent="gh-power-select/trigger"

--- a/app/components/gh-publishmenu-scheduled.js
+++ b/app/components/gh-publishmenu-scheduled.js
@@ -26,6 +26,10 @@ export default class GhPublishmenuScheduledComponent extends Component {
         return publishedAtUTC.toNow(true);
     }
 
+    get selectedNewsletter() {
+        return this.args.availableNewsletters.find(n => n.id === this.args.post.newsletterId);
+    }
+
     constructor() {
         super(...arguments);
         this.minDate = new Date();

--- a/app/components/gh-publishmenu.hbs
+++ b/app/components/gh-publishmenu.hbs
@@ -26,6 +26,7 @@
                 @setTypedDateError={{action (mut this.typedDateError)}}
                 @isSendingEmailLimited={{this.isSendingEmailLimited}}
                 @sendingEmailLimitError={{this.sendingEmailLimitError}}
+                @availableNewsletters={{this.availableNewsletters}}
                 data-test-publishmenu-scheduled="true" />
 
         {{else}}

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -111,6 +111,9 @@ export default Model.extend(Comparable, ValidationEngine, {
     featureImageAlt: attr('string'),
     featureImageCaption: attr('string'),
 
+    // TODO: delete when newsletter relationship/embed is fully defined
+    newsletterId: attr(),
+
     authors: hasMany('user', {embedded: 'always', async: false}),
     createdBy: belongsTo('user', {async: true}),
     email: belongsTo('email', {async: false}),


### PR DESCRIPTION
no issue

If you scheduled a post to a specific newsletter it was no longer visible in the scheduled state of the publish menu making it difficult to know the behaviour when coming back to a scheduled post.

- duplicated the newsletter dropdown from the draft to the scheduled state components and disabled it the same as the other recipient options
- added temporary workaround for missing newsletter embed for the posts endpoint in the API
  - adds `newsletterId` attribute to the post model
  - uses `post.newsletterId` to find the matching newsletter model from the available newsletters list