### PR TITLE
Fixed mergeDates when only one item in list

### DIFF
--- a/app/services/dashboard-stats.js
+++ b/app/services/dashboard-stats.js
@@ -376,7 +376,7 @@ export default class DashboardStatsService extends Service {
             const [current, ...rest] = list;
 
             if (!current) {
-                return [entry];
+                return entry ? [entry] : [];
             }
 
             if (!entry) {

--- a/app/services/dashboard-stats.js
+++ b/app/services/dashboard-stats.js
@@ -376,7 +376,7 @@ export default class DashboardStatsService extends Service {
             const [current, ...rest] = list;
 
             if (!current) {
-                return entry;
+                return [entry];
             }
 
             if (!entry) {


### PR DESCRIPTION
The exit clause of the mergeDates function should return an array rather
than an object, to ensure that an array is always returned. Because we
are using the concat method when recursing, this continues to work for
longer lists.
