### PR TITLE
Updated post email preview to render with the selected newsletter

### DIFF
--- a/app/components/editor-labs/modals/preview.hbs
+++ b/app/components/editor-labs/modals/preview.hbs
@@ -48,7 +48,7 @@
         {{/if}}
 
         {{#if (and (eq this.tab "email") @data.post.isPost)}}
-            <EditorLabs::Modals::Preview::Email @post={{@data.post}} />
+            <EditorLabs::Modals::Preview::Email @post={{@data.post}} @newsletter={{@data.newsletter}} />
         {{/if}}
 
         {{#if (eq this.tab "social")}}

--- a/app/components/editor-labs/modals/preview/email.js
+++ b/app/components/editor-labs/modals/preview/email.js
@@ -32,7 +32,10 @@ export default class ModalPostPreviewEmailComponent extends Component {
     @tracked memberSegment = 'status:free';
     @tracked previewEmailAddress = this.session.user.email;
     @tracked sendPreviewEmailError = '';
-    @tracked newsletter = null;
+
+    get newsletter() {
+        return this.args.post.newsletter || this.args.newsletter;
+    }
 
     get mailgunIsEnabled() {
         return this.config.get('mailgunIsConfigured') ||
@@ -109,17 +112,6 @@ export default class ModalPostPreviewEmailComponent extends Component {
         let {html, subject, memberSegment} = this;
         let {post} = this.args;
 
-        // Fetch newsletter
-        if (!this.newsletter && post.newsletter) {
-            this.newsletter = post.newsletter;   
-        }
-            
-        if (!this.newsletter) {
-            const newsletters = (await this.store.query('newsletter', {filter: 'status:active', limit: 1})).toArray();
-            const defaultNewsletter = newsletters[0];
-            this.newsletter = defaultNewsletter;    
-        }
-
         if (html && subject && memberSegment === this._lastMemberSegment) {
             return {html, subject};
         }
@@ -138,6 +130,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
         } else {
             let url = new URL(this.ghostPaths.url.api('/email_previews/posts', post.id), window.location.href);
             url.searchParams.set('memberSegment', this.memberSegment);
+            url.searchParams.set('newsletter', this.newsletter.slug);
 
             let response = await this.ajax.request(url.href);
             let [emailPreview] = response.email_previews;

--- a/app/components/editor-labs/publish-management.js
+++ b/app/components/editor-labs/publish-management.js
@@ -85,6 +85,7 @@ export default class PublishManagement extends Component {
             // without restarting the flow or causing flicker
 
             this.previewModal = this.modals.open(PreviewModal, {
+                newsletter: this.publishOptions.newsletter,
                 post: this.publishOptions.post,
                 hasDirtyAttributes: this.args.hasUnsavedChanges,
                 saveTask: this.saveTask,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1621
reqs https://github.com/TryGhost/Ghost/pull/14820

We want to allow previewing emails based on the newsletter selected in the publish flow.

- passed the selected newsletter from `<PublishManagement>` through to the preview modal then through to the email preview component
- removed tracked `newsletter` property and fetching of the default newsletter in the email preview component that was in place to allow `senderName` and `senderEmail` to be used in the component
- added `newsletter` getter that uses the `post.newsletter` or the passed in selected newsletter
- updated the email preview fetching to pass `?newsletter=slug` so the email is rendered with the correct newlsetter
