### PR TITLE
Moved logic for publish confirm button text states into backing class

### DIFF
--- a/app/components/editor/modals/publish-flow/confirm.hbs
+++ b/app/components/editor/modals/publish-flow/confirm.hbs
@@ -59,46 +59,14 @@
 {{/if}}
 
 <div class="gh-publish-cta">
-    {{#if @publishOptions.isScheduled}}
-        <GhTaskButton
-            @task={{this.confirmTask}}
-            @buttonText={{this.confirmButtonText}}
-            @runningText="Scheduling"
-            @successText="Scheduled"
-            @class="gh-btn gh-btn-large"
-            @idleClass="gh-btn-pulse"
-            @runningClass="gh-btn-green gh-btn-icon"
-        />
-    {{else if @publishOptions.willOnlyEmail}}
-        <GhTaskButton
-            @task={{this.confirmTask}}
-            @buttonText={{this.confirmButtonText}}
-            @runningText="Sending"
-            @successText="Sent"
-            @class="gh-btn gh-btn-large"
-            @idleClass="gh-btn-pulse"
-            @runningClass="gh-btn-green gh-btn-icon"
-        />
-    {{else if this.willEmail}}
-        <GhTaskButton
-            @task={{this.confirmTask}}
-            @buttonText={{this.confirmButtonText}}
-            @runningText="Publishing & sending"
-            @successText="Published & sent"
-            @class="gh-btn gh-btn-large"
-            @idleClass="gh-btn-pulse"
-            @runningClass="gh-btn-green gh-btn-icon"
-        />
-    {{else}}
-        <GhTaskButton
-            @task={{this.confirmTask}}
-            @buttonText={{this.confirmButtonText}}
-            @runningText="Publishing"
-            @successText="Published"
-            @class="gh-btn gh-btn-large"
-            @idleClass="gh-btn-pulse"
-            @runningClass="gh-btn-green gh-btn-icon"
-        />
-    {{/if}}
+    <GhTaskButton
+        @task={{this.confirmTask}}
+        @buttonText={{this.confirmButtonText}}
+        @runningText={{this.confirmRunningText}}
+        @successText={{this.confirmSuccessText}}
+        @class="gh-btn gh-btn-large"
+        @idleClass="gh-btn-pulse"
+        @runningClass="gh-btn-green gh-btn-icon"
+    />
     <button type="button" class="gh-btn gh-btn-link gh-btn-large gh-publish-cta-secondary" {{on "click" @cancel}}>Back to settings</button>
 </div>

--- a/app/components/editor/modals/publish-flow/confirm.js
+++ b/app/components/editor/modals/publish-flow/confirm.js
@@ -21,17 +21,48 @@ export default class PublishFlowOptions extends Component {
     willEmail = this.args.publishOptions.willEmail;
     willPublish = this.args.publishOptions.willPublish;
 
-    get confirmButtonText() {
-        const publishOptions = this.args.publishOptions;
+    buttonTextMap = {
+        'publish+send': {
+            idle: 'Publish & Send',
+            running: 'Publishing & sending',
+            success: 'Published & sent'
+        },
+        send: {
+            idle: 'Send email',
+            running: 'Sending',
+            success: 'Sent'
+        },
+        publish: {
+            idle: 'Publish',
+            running: 'Publishing',
+            success: 'Published'
+        },
+        schedule: {
+            // idle: '', - uses underlying publish type text
+            running: 'Scheduling',
+            success: 'Scheduled'
+        }
+    };
 
+    get publishType() {
+        const {publishOptions} = this.args;
+
+        if (this.willPublish && this.willEmail) {
+            return 'publish+send';
+        } else if (publishOptions.willOnlyEmail) {
+            return 'send';
+        } else {
+            return 'publish';
+        }
+    }
+
+    get confirmButtonText() {
         let buttonText = '';
 
-        if (publishOptions.willPublish && publishOptions.willEmail) {
-            buttonText = 'Publish & send';
-        } else if (publishOptions.willOnlyEmail) {
-            buttonText = 'Send email';
-        } else {
-            buttonText = `Publish ${this.args.publishOptions.post.displayName}`;
+        buttonText = this.buttonTextMap[this.publishType].idle;
+
+        if (this.publishType === 'publish') {
+            buttonText += ` ${this.args.publishOptions.post.displayName}`;
         }
 
         if (this.args.publishOptions.isScheduled) {
@@ -42,6 +73,16 @@ export default class PublishFlowOptions extends Component {
         }
 
         return buttonText;
+    }
+
+    get confirmRunningText() {
+        const publishType = this.args.publishOptions.isScheduled ? 'schedule' : this.publishType;
+        return this.buttonTextMap[publishType].running;
+    }
+
+    get confirmSuccessText() {
+        const publishType = this.args.publishOptions.isScheduled ? 'schedule' : this.publishType;
+        return this.buttonTextMap[publishType].success;
     }
 
     @task({drop: true})


### PR DESCRIPTION
refs https://github.com/TryGhost/Admin/commit/d81d3c9d5a4ce3b5e938af25aa45d9ccf40e191b

- keeps text and logic together, avoids duplication of button code just for changing the running/success text
- added a `buttonTextMap` to keep the high-level text states in one place
- added `publishType` getter for easier switching between states in other getters and to have one place for the logic
- updated `confirmButtonText` getter and added `confirmRunningText` and `confirmSuccessText` getters that read from the button text map so the pattern used for getting text to pass as arguments in the template is consistent
