### PR TITLE
Fixed raw JS error messages appearing in alerts

### DIFF
--- a/tests/unit/services/notifications-test.js
+++ b/tests/unit/services/notifications-test.js
@@ -8,6 +8,8 @@ import {expect} from 'chai';
 import {run} from '@ember/runloop';
 import {setupTest} from 'ember-mocha';
 
+import {GENERIC_ERROR_MESSAGE} from 'ghost-admin/services/notifications';
+
 // notifications service determines if a notification is a model instance by
 // checking `notification.constructor.modelName === 'notification'`
 const NotificationStub = EmberObject.extend();
@@ -56,6 +58,23 @@ describe('Unit: Service: notifications', function () {
 
         expect(notifications.content)
             .to.deep.include({message: 'Test', status: 'notification'});
+    });
+
+    it('#handleNotification shows generic error message when a word matches built-in error type', function () {
+        let notifications = this.owner.lookup('service:notifications');
+
+        notifications.handleNotification({message: 'TypeError test'});
+        expect(notifications.content[0].message).to.equal(GENERIC_ERROR_MESSAGE);
+
+        notifications.clearAll();
+        expect(notifications.content.length).to.equal(0);
+
+        notifications.handleNotification({message: 'TypeError: Testing'});
+        expect(notifications.content[0].message).to.equal(GENERIC_ERROR_MESSAGE);
+
+        notifications.clearAll();
+        notifications.handleNotification({message: 'Unknown error - TypeError, cannot save invite.'});
+        expect(notifications.content[0].message).to.equal(GENERIC_ERROR_MESSAGE);
     });
 
     it('#showAlert adds POJO alerts', function () {
@@ -253,6 +272,15 @@ describe('Unit: Service: notifications', function () {
         expect(alert.status).to.equal('alert');
         expect(alert.type).to.equal('error');
         expect(alert.key).to.equal('api-error');
+    });
+
+    it('#showAPIError shows generic error for built-in error types', function () {
+        let notifications = this.owner.lookup('service:notifications');
+        const error = new TypeError('Testing');
+
+        notifications.showAPIError(error);
+
+        expect(notifications.alerts[0].message).to.equal(GENERIC_ERROR_MESSAGE);
     });
 
     it('#displayDelayed moves delayed notifications into content', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1613

We use `notifications.showAPIError()` in many of our try/catch routines but those can also pick up standard JS errors which can result in ugly and useless messages showing in alerts.

- added a list of known built-in JS error type names to check against and a generic error message to be used in place of ones we know shouldn't be displayed
- in `showAPIError(obj)` check `obj.name` against the known list and swap the message for a generic one
  - only the message is swapped, we still log the full/original error to Sentry
- in `handleNotification(msg)` which is the final method used when displaying any alert/notification, extract all words in the supplied message and check that against the known list and swap the message on a match. This handles situations where the API might give us a raw JS error message in the message string
