### PR TITLE
🎨 Reduced favicon requirements

### DIFF
--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -14,11 +14,11 @@ import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
 export const IMAGE_MIME_TYPES = 'image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp';
-export const IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png', 'svg', 'webp'];
+export const IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png', 'svg', 'svgz', 'webp'];
 export const IMAGE_PARAMS = {purpose: 'image'};
 
-export const ICON_EXTENSIONS = ['ico', 'png'];
-export const ICON_MIME_TYPES = 'image/png,image/x-icon';
+export const ICON_EXTENSIONS = ['gif', 'ico', 'jpg', 'jpeg', 'png', 'svg', 'svgz', 'webp'];
+export const ICON_MIME_TYPES = 'image/x-icon,image/vnd.microsoft.icon,image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp';
 export const ICON_PARAMS = {purpose: 'icon'};
 
 export default Component.extend({

--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -174,7 +174,7 @@
     width: 32px;
     height: 32px;
     background-color: transparent;
-    background-size: 32px;
+    background-size: cover;
     border-radius: 6px;
 }
 


### PR DESCRIPTION
refs TryGhost/Team#1652

> **Warning**
> Requires https://github.com/TryGhost/Ghost/pull/14918

- Support picking new image types in the favicon image uploader.
- Added support for non-square and not resizable files (e.g., svg files) as favicon (cover background image).