### PR TITLE
Put plus menu button on the screen on mobile

### DIFF
--- a/app/styles/components/koenig.css
+++ b/app/styles/components/koenig.css
@@ -981,9 +981,9 @@
 }
 
 
-@media (max-width: 1024px) {
+@media (max-width: 500px) {
   .koenig-plus-menu-button {
-        right:10px;
+        right: -34px;
   }
 }
 

--- a/lib/koenig-editor/addon/components/koenig-plus-menu.hbs
+++ b/lib/koenig-editor/addon/components/koenig-plus-menu.hbs
@@ -1,5 +1,5 @@
 {{#if this.showButton}}
-    <button aria-label="Add a card" class="koenig-plus-menu-button flex justify-center items-center relative w9 h9 ba b--midlightgrey-l2 bg-white br-100 anim-normal" onclick={{action "openMenu"}} type="button">{{svg-jar "plus" class="w4 h4 stroke-middarkgrey i-strokew--2"}}</button>
+    <button aria-label="Add a card" class="koenig-plus-menu-button flex justify-center items-center relative w7 h7 w9-ns h9-ns ba b--midlightgrey-l2 bg-white br-100 anim-normal" onclick={{action "openMenu"}} type="button">{{svg-jar "plus" class="w4 h4 stroke-middarkgrey i-strokew--2"}}</button>
 {{/if}}
 
 {{#if this.showMenu}}


### PR DESCRIPTION
Fix the right positioning and size of the icon for mobile display
Addresses https://github.com/TryGhost/Ghost/issues/14948

I also adjusted the breakpoint at 500px to match the rest of the styles in the file.

Below are a couple of example screenshots, of the button before/after clicking. One from the browser responsive view, the other in iOS Safari.

![Schermafbeelding 2022-06-14 om 08 49 30](https://user-images.githubusercontent.com/2406051/173514640-d29129f3-6e14-4b5a-8128-55fd1e8c623e.png)

![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-14 at 09 03 37](https://user-images.githubusercontent.com/2406051/173514615-22951826-18a7-4775-8337-e9baac0e0b1b.png)
 