### PR TITLE
🐛 Fixed scheduled post datepicker sometimes picking day before selected date

### DIFF
--- a/app/components/editor/publish-options/publish-at.hbs
+++ b/app/components/editor/publish-options/publish-at.hbs
@@ -17,7 +17,7 @@
             @time={{moment-format (moment-site-tz @publishOptions.scheduledAtUTC) "HH:mm"}}
             @setDate={{this.setDate}}
             @setTime={{this.setTime}}
-            @minDate={{@publishOptions.minScheduledAt}}
+            @minDate={{moment-site-tz @publishOptions.minScheduledAt}}
             @isActive={{@publishOptions.isScheduled}}
             @renderInPlace={{false}}
         />

--- a/app/components/editor/publish-options/publish-at.js
+++ b/app/components/editor/publish-options/publish-at.js
@@ -8,11 +8,19 @@ export default class PublishAtOption extends Component {
 
     @action
     setDate(selectedDate) {
-        const newDate = moment(this.args.publishOptions.scheduledAtUTC);
-        const {years, months, date} = moment(selectedDate).toObject();
+        const selectedMoment = moment(selectedDate);
+        const {years, months, date} = selectedMoment.toObject();
 
+        // Create a new moment from existing scheduledAtUTC _in site timezone_.
+        // This ensures we're setting the date correctly because we don't need
+        // to account for the converted UTC date being yesterday/tomorrow.
+        const newDate = moment.tz(
+            this.args.publishOptions.scheduledAtUTC,
+            this.settings.get('timezone')
+        );
         newDate.set({years, months, date});
 
+        // converts back to UTC
         this.args.publishOptions.setScheduledAt(newDate);
     }
 

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -119,7 +119,7 @@ export default class GhDateTimePicker extends Component {
         }
         this.set('_previousTime', this._time);
 
-        // unless min/max date is at midnight moment will diable that day
+        // unless min/max date is at midnight moment will disable that day
         if (minDate === 'now') {
             this.set('_minDate', moment(moment().format(DATE_FORMAT)));
         } else if (!isBlank(minDate)) {


### PR DESCRIPTION
no issue

- in sites with a timezone that is negatively offset from UTC at certain times of day when the equivalent UTC date would be the next day, selecting a date when scheduling a post would select a day before the selected date
- fixed the date adjustment when applying the selected date to properly take timezones into account
