### PR TITLE
Updated copy for user deletion modal

### DIFF
--- a/app/components/modal-delete-user.hbs
+++ b/app/components/modal-delete-user.hbs
@@ -6,7 +6,11 @@
 <div class="modal-body">
     {{#if this.user.count.posts}}
         <p>
-            <strong>{{this.user.name}}</strong> and their <strong data-test-text="user-post-count">{{gh-pluralize this.user.count.posts 'post'}}</strong> will be permanently deleted.
+            <strong>{{this.user.name}}</strong> will be permanently deleted and their <strong data-test-text="user-post-count">{{gh-pluralize this.user.count.posts 'post'}}</strong> will be automatically assigned to <strong>{{this.ownerUser.name}}</strong>.
+        </p>
+
+        <p>
+            To make these easy to find in the future, each post will be given an internal tag of <strong>#{{this.user.slug}}</strong>
         </p>
     {{else}}
         <p>

--- a/app/components/modal-delete-user.js
+++ b/app/components/modal-delete-user.js
@@ -1,8 +1,11 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
 import {alias} from '@ember/object/computed';
+import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({
+    store: service(),
+
     // Allowed actions
     confirm: () => {},
 
@@ -12,6 +15,10 @@ export default ModalComponent.extend({
         confirm() {
             this.deleteUser.perform();
         }
+    },
+
+    get ownerUser() {
+        return this.store.peekAll('user').findBy('isOwnerOnly', true);
     },
 
     deleteUser: task(function* () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/15008

- When the user is removed the new flow adds a special tag and reassignes all the user-owned posts to the owner user. Updated copy to inform about this behavior clearly
