### PR TITLE
🐛 Excluded plan changes from paid subscribers graph in dashboard

### DIFF
--- a/app/components/dashboard/charts/paid-breakdown.js
+++ b/app/components/dashboard/charts/paid-breakdown.js
@@ -198,8 +198,8 @@ export default class PaidBreakdown extends Component {
     get chartData() {
         const stats = this.dashboardStats.filledSubscriptionCountStats;
         const labels = stats.map(stat => stat.date);
-        const newData = stats.map(stat => stat.positiveDelta);
-        const canceledData = stats.map(stat => -stat.negativeDelta);
+        const newData = stats.map(stat => stat.signups);
+        const canceledData = stats.map(stat => -stat.cancellations);
         let barThickness = 5;
 
         if (newData.length >= 30 + 1 && newData.length < 90) {

--- a/app/services/dashboard-stats.js
+++ b/app/services/dashboard-stats.js
@@ -243,10 +243,12 @@ export default class DashboardStatsService extends Service {
                 free: obj.free,
                 comped: obj.comped,
                 paidCanceled: 0,
-                paidSubscribed: 0
+                paidSubscribed: 0,
+                signups: 0,
+                cancellations: 0
             };
         }
-        return this.fillMissingDates(this.memberCountStats, {paid: 0, free: 0, comped: 0, paidCanceled: 0, paidSubscribed: 0}, copyData, this.chartDays);
+        return this.fillMissingDates(this.memberCountStats, {paid: 0, free: 0, comped: 0, paidCanceled: 0, paidSubscribed: 0, signups: 0, cancellations: 0}, copyData, this.chartDays);
     }
 
     get filledMrrStats() {
@@ -411,7 +413,9 @@ export default class DashboardStatsService extends Service {
                     date: current.date,
                     count: current.count,
                     positiveDelta: current.positive_delta,
-                    negativeDelta: current.negative_delta
+                    negativeDelta: current.negative_delta,
+                    signups: current.signups,
+                    cancellations: current.cancellations
                 });
             }
 
@@ -420,7 +424,9 @@ export default class DashboardStatsService extends Service {
                     date: entry.date,
                     count: entry.count + current.count,
                     positiveDelta: entry.positiveDelta + current.positive_delta,
-                    negativeDelta: entry.negativeDelta + current.negative_delta
+                    negativeDelta: entry.negativeDelta + current.negative_delta,
+                    signups: entry.signups + current.signups,
+                    cancellations: entry.cancellations + current.cancellations
                 });
             }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1673

When a user switches plan, the paid subscribers delta chart on the dashboard displays the change as a cancellation plus a new subscription. This display is misleading and confusing - instead, plan changes should be excluded from the paid subscribers delta chart.

Awaiting https://github.com/TryGhost/Ghost/pull/15023