### PR TITLE
Fixed using the correct token for Explore

### DIFF
--- a/app/controllers/explore.js
+++ b/app/controllers/explore.js
@@ -18,7 +18,7 @@ export default class ExploreController extends Controller {
         const explore = this.model.findBy('slug', 'ghost-explore');
         const adminKey = explore.adminKey;
 
-        return `${adminKey.id}:${adminKey.secret}`;
+        return adminKey.secret;
     }
 
     @action

--- a/app/styles/layouts/explore.css
+++ b/app/styles/layouts/explore.css
@@ -46,12 +46,12 @@
 }
 
 .explore-header h1 {
-    margin: 2rem 0 0;
-    font-size: 3.7rem;
+    margin: 1.6rem 0 0;
+    font-size: 3.6rem;
     text-align: center;
     font-weight: 700;
     letter-spacing: -.03em;
-    line-height: 45px;
+    line-height: 40px;
 }
 
 .explore-api {


### PR DESCRIPTION
no issue

- The `adminKey.secret` property is already in the correct format of `admiKey.Id:adminKey.secret` so we were returning the id twice as query param
- Minor style adjustments for Explore